### PR TITLE
bug:  Get config not passing along users preferred language

### DIFF
--- a/Sources/KetchSDK/Core/ApiRequest.swift
+++ b/Sources/KetchSDK/Core/ApiRequest.swift
@@ -18,7 +18,7 @@ struct EndPoint {
     let queryItems: [URLQueryItem]
 
     static func config(organization: String, property: String) -> EndPoint {
-        return EndPoint(
+        EndPoint(
             scheme: defaultScheme,
             host: ketchHost,
             path: [ketchApi, ketchApiVersion, "config", organization, property, "config.json"].joined(separator: "/"),
@@ -159,8 +159,9 @@ class DefaultApiClient: ApiClient {
 
     private static func urlRequest(with request: ApiRequest) -> URLRequest? {
         guard let url = request.endPoint.url else { return nil }
-        var urlRequest = URLRequest(url: url)
         
+        var urlRequest = URLRequest(url: url)
+
         urlRequest.httpBody = request.body
         urlRequest.httpMethod = request.method.rawValue
         urlRequest.cachePolicy = .reloadIgnoringLocalCacheData


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Get config not passing along users preferred language

## Description of this change
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
> Added users preferred device language as query parameter on the get config call

## Why is this change being made?
- [ X ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
> Tested locally

## Related issues
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
> 

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.
