### PR TITLE
chore: add podspec and fix pod lint warnings

### DIFF
--- a/KetchSDK.podspec
+++ b/KetchSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'KetchSDK'
-  s.version          = '4.0.1'
+  s.version          = '4.0.2'
   s.summary          = 'Ketch iOS SDK'
   s.swift_versions   = '5.7'
 

--- a/KetchSDK.podspec
+++ b/KetchSDK.podspec
@@ -1,0 +1,45 @@
+#
+# Be sure to run `pod lib lint KetchSDK.podspec' to ensure this is a
+# valid spec before submitting.
+#
+# Any lines starting with a # are optional, but their use is encouraged
+# To learn more about a Podspec see https://guides.cocoapods.org/syntax/podspec.html
+#
+
+Pod::Spec.new do |s|
+  s.name             = 'KetchSDK'
+  s.version          = '4.0.1'
+  s.summary          = 'Ketch iOS SDK'
+  s.swift_versions   = '5.7'
+
+# This description is used to generate tags and improve search results.
+#   * Think: What does it do? Why did you write it? What is the focus?
+#   * Try to keep it short, snappy and to the point.
+#   * Write the description between the DESC delimiters below.
+#   * Finally, don't worry about the indent, CocoaPods strips it!
+
+  s.description      = <<-DESC
+  The Ketch iOS SDK. See https://developers.ketch.com/docs/ketch-sdk-for-ios-v20 for more info.
+                       DESC
+
+  s.homepage         = 'https://github.com/ketch-com/ketch-ios'
+  # s.screenshots     = 'www.example.com/screenshots_1', 'www.example.com/screenshots_2'
+  s.license          = { :type => 'MIT', :file => 'LICENSE' }
+  s.author           = { 'Justin Boileau' => 'justin.boileau@ketch.com' }
+  s.source           = { :git => 'https://github.com/ketch-com/ketch-ios.git', :tag => s.version.to_s }
+  # s.social_media_url = 'https://twitter.com/<TWITTER_USERNAME>'
+
+  s.ios.deployment_target = '15.0'
+
+  # s.source_files = 'Sources/KetchSDK/**/*'
+  s.source_files = 'Sources/KetchSDK/**/*.{h,m,swift}'
+  
+  # s.resource_bundles = {
+  #   'KetchSDK' => ['KetchSDK/Assets/*.png']
+  # }
+
+  # s.public_header_files = 'Pod/Classes/**/*.h'
+  # s.frameworks = 'UIKit', 'MapKit'
+  # s.dependency 'AFNetworking', '~> 2.3'
+end
+

--- a/KetchSDK.podspec
+++ b/KetchSDK.podspec
@@ -1,45 +1,20 @@
-#
-# Be sure to run `pod lib lint KetchSDK.podspec' to ensure this is a
-# valid spec before submitting.
-#
-# Any lines starting with a # are optional, but their use is encouraged
-# To learn more about a Podspec see https://guides.cocoapods.org/syntax/podspec.html
-#
-
 Pod::Spec.new do |s|
   s.name             = 'KetchSDK'
   s.version          = '4.0.1'
   s.summary          = 'Ketch iOS SDK'
   s.swift_versions   = '5.7'
 
-# This description is used to generate tags and improve search results.
-#   * Think: What does it do? Why did you write it? What is the focus?
-#   * Try to keep it short, snappy and to the point.
-#   * Write the description between the DESC delimiters below.
-#   * Finally, don't worry about the indent, CocoaPods strips it!
-
   s.description      = <<-DESC
   The Ketch iOS SDK. See https://developers.ketch.com/docs/ketch-sdk-for-ios-v20 for more info.
                        DESC
 
   s.homepage         = 'https://github.com/ketch-com/ketch-ios'
-  # s.screenshots     = 'www.example.com/screenshots_1', 'www.example.com/screenshots_2'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
   s.author           = { 'Justin Boileau' => 'justin.boileau@ketch.com' }
   s.source           = { :git => 'https://github.com/ketch-com/ketch-ios.git', :tag => s.version.to_s }
-  # s.social_media_url = 'https://twitter.com/<TWITTER_USERNAME>'
 
   s.ios.deployment_target = '15.0'
 
-  # s.source_files = 'Sources/KetchSDK/**/*'
   s.source_files = 'Sources/KetchSDK/**/*.{h,m,swift}'
-  
-  # s.resource_bundles = {
-  #   'KetchSDK' => ['KetchSDK/Assets/*.png']
-  # }
 
-  # s.public_header_files = 'Pod/Classes/**/*.h'
-  # s.frameworks = 'UIKit', 'MapKit'
-  # s.dependency 'AFNetworking', '~> 2.3'
 end
-

--- a/Sources/KetchSDK/UI/Extensions/View+ResponsiveSheet.swift
+++ b/Sources/KetchSDK/UI/Extensions/View+ResponsiveSheet.swift
@@ -192,7 +192,11 @@ fileprivate struct ClearBackgroundView: UIViewRepresentable {
 //MARK: - EnvironmentKey & Values
 fileprivate struct SafeAreaInsetsKey: EnvironmentKey {
     static var defaultValue: EdgeInsets {
-        (UIApplication.shared.windows.first(where: { $0.isKeyWindow })?.safeAreaInsets ?? .zero).insets
+        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+              let keyWindow = windowScene.windows.first(where: { $0.isKeyWindow }) else {
+            return EdgeInsets.init(top: 0, leading: 0, bottom: 0, trailing: 0)
+        }
+        return keyWindow.safeAreaInsets.insets
     }
 }
 

--- a/Sources/KetchSDK/UI/KetchUI.swift
+++ b/Sources/KetchSDK/UI/KetchUI.swift
@@ -93,7 +93,7 @@ public final class KetchUI: ObservableObject {
             
             isConfigLoaded = true
             
-            if let experienceToShow {
+            if experienceToShow != nil {
                 showExperience()
                 self.experienceToShow = nil
                 isConfigLoaded = false


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Code generated by shipbuilder init 1.21.3. DO NOT EDIT. -->

## Description of this change

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

> Adds a podspec so we can publish our SDK to cocoapods

## Why is this change being made?

- [x] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Local using `pod lib init KetchSDK.podspec`

## Related issues

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.
