### PR TITLE
fix: index.html reference when importing via pod

### DIFF
--- a/KetchSDK.podspec
+++ b/KetchSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'KetchSDK'
-  s.version          = '4.0.2'
+  s.version          = '4.0.3'
   s.summary          = 'Ketch iOS SDK'
   s.swift_versions   = '5.7'
 

--- a/KetchSDK.podspec
+++ b/KetchSDK.podspec
@@ -15,6 +15,7 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '15.0'
 
-  s.source_files = 'Sources/KetchSDK/**/*.{h,m,swift}'
+  s.source_files = 'Sources/KetchSDK/**/*.{h,m,swift,html}'
+  s.resources = 'Sources/KetchSDK/**/*.html'
 
 end

--- a/Sources/KetchSDK/UI/PresentationItem/WebConfig.swift
+++ b/Sources/KetchSDK/UI/PresentationItem/WebConfig.swift
@@ -47,7 +47,7 @@ struct WebConfig {
     }
 
     private var fileUrl: URL? {
-        let url = Bundle.ketchUI!.url(forResource: htmlFileName, withExtension: "html")!
+        let url = Bundle(for: KetchUI.self).url(forResource: htmlFileName, withExtension: "html")!
         var urlComponents = URLComponents(string: url.absoluteString)
         urlComponents?.queryItems = queryItems
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Code generated by shipbuilder init 1.21.3. DO NOT EDIT. -->

## Description of this change

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

> Includes index.html in the pod and also marks it as a resource so it is accessible via the Bundle() method that the webview uses

## Why is this change being made?

- [ ] Chore (non-functional changes)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally, installing pod in sample wrapper SDK 

## Related issues

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.
