### PR TITLE
fix: index.html location for SPM and add HideExperienceStatus

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,6 +21,9 @@ let package = Package(
             resources: [
                 .copy("Assets.xcassets"),
                 .copy("index.html")
+            ],
+            swiftSettings: [
+                .define("SWIFT_PACKAGE")
             ]
         ),
         .testTarget(

--- a/Sources/KetchSDK/Core/KetchSDK.swift
+++ b/Sources/KetchSDK/Core/KetchSDK.swift
@@ -158,3 +158,13 @@ extension KetchSDK {
             .eraseToAnyPublisher()
     }
 }
+
+extension KetchSDK {
+    public enum HideExperienceStatus: String, Codable {
+        case SetConsent = "setConsent"
+        case InvokeRight = "invokeRight"
+        case Close = "close"
+        case WillNotShow = "willNotShow"
+        case None = "none"
+    }
+}

--- a/Sources/KetchSDK/UI/KetchUI.swift
+++ b/Sources/KetchSDK/UI/KetchUI.swift
@@ -74,8 +74,8 @@ public final class KetchUI: ObservableObject {
     
     private func handle(webPresentationEvent: WebPresentationItem.Event) {
         switch webPresentationEvent {
-        case .onClose:
-            didCloseExperience()
+        case .onClose(let status):
+            didCloseExperience(status: status)
             
         case .show(let content):
             if isConfigLoaded {
@@ -86,7 +86,7 @@ public final class KetchUI: ObservableObject {
             }
             
         case .tapOutside:
-            didCloseExperience()
+            didCloseExperience(status: KetchSDK.HideExperienceStatus.None)
             
         case .configurationLoaded(let configuration):
             self.ketch.configuration = configuration
@@ -128,9 +128,9 @@ public final class KetchUI: ObservableObject {
         }
     }
     
-    private func didCloseExperience() {
+    private func didCloseExperience(status: KetchSDK.HideExperienceStatus) {
         webPresentationItem = nil
-        eventListener?.onDismiss()
+        eventListener?.onDismiss(status: status)
     }
     
     private var display: KetchSDK.Configuration.Experience.ContentDisplay {
@@ -272,7 +272,7 @@ extension KetchUI {
 
 public protocol KetchEventListener: AnyObject {
     func onShow()
-    func onDismiss()
+    func onDismiss(status: KetchSDK.HideExperienceStatus)
     func onEnvironmentUpdated(environment: String?)
     func onRegionInfoUpdated(regionInfo: String?)
     func onJurisdictionUpdated(jurisdiction: String?)

--- a/Sources/KetchSDK/UI/PresentationItem/WebConfig.swift
+++ b/Sources/KetchSDK/UI/PresentationItem/WebConfig.swift
@@ -47,10 +47,15 @@ struct WebConfig {
     }
 
     private var fileUrl: URL? {
-        let url = Bundle(for: KetchUI.self).url(forResource: htmlFileName, withExtension: "html")!
+        // Handle bundling differences with swift packages vs cocoa pods when fetching static assests (index.html)
+        #if SWIFT_PACKAGE
+            // SWIFT_PACKAGE is a variable we define in Package.swift
+            let url = Bundle.ketchUI!.url(forResource: htmlFileName, withExtension: "html")!
+        #else
+            let url = Bundle(for: KetchUI.self).url(forResource: htmlFileName, withExtension: "html")!
+        #endif
         var urlComponents = URLComponents(string: url.absoluteString)
         urlComponents?.queryItems = queryItems
-
         return urlComponents?.url
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Code generated by shipbuilder init 1.21.3. DO NOT EDIT. -->

## Description of this change

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

- Fixes issue where the `index.html` asset could not be located for swift package manager builds
- Adds `HideExperienceStatus` to the `onDismiss` handler

## Why is this change being made?

- [ ] Chore (non-functional changes)
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Local with sample application

## Related issues

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.
