### PR TITLE
fix(privacy-protocols): clear NSUserDefaults on load and reload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,36 +3,35 @@ name: iOS CI
 on:
   push:
     branches:
-    - main
+      - main
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     env:
       ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
       ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
 
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - name: Step 1 - Create a temporary artifact folder ketchSDK
-      run: mkdir ketchSDK
+      - name: Step 1 - Create a temporary artifact folder ketchSDK
+        run: mkdir ketchSDK
 
-    - name: Step 2 - Add artifacts to publish to the temp folder
-      run: |
-        cp -a Sources ketchSDK/
-        cp -a LICENSE ketchSDK/
+      - name: Step 2 - Add artifacts to publish to the temp folder
+        run: |
+          cp -a Sources ketchSDK/
+          cp -a LICENSE ketchSDK/
 
-    - name: Step 3 - Archive using zip or tar
-      uses: NSCoder/archive-action@v1.0.0
-      with:
-        args: tar -czvf ketchSDK.tar.gz ketchSDK/
+      - name: Step 3 - Archive using zip or tar
+        uses: NSCoder/archive-action@v1.0.0
+        with:
+          args: tar -czvf ketchSDK.tar.gz ketchSDK/
 
-    - name: Step 4 - Use the Upload Artifact GitHub Action
-      uses: actions/upload-artifact@v2
-      with:
-        name: ketchSDK
-        path: ketchSDK.tar.gz
+      - name: Step 4 - Use the Upload Artifact GitHub Action
+        uses: actions/upload-artifact@v4
+        with:
+          name: ketchSDK
+          path: ketchSDK.tar.gz


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Code generated by shipbuilder init 1.21.3. DO NOT EDIT. -->

## Description of this change

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

> This mirrors a change made in ketch-android to clear privacy protocol key-value pairs when loading/reloading the SDK.

USPrivacy string:
<img width="405" alt="Screenshot 2025-01-09 at 9 14 12 PM" src="https://github.com/user-attachments/assets/52e50953-1b79-443f-98f8-1adf507adcbf" />

USPrivacy:
<img width="740" alt="Screenshot 2025-01-09 at 9 14 39 PM" src="https://github.com/user-attachments/assets/d53aeb12-f82c-4c0e-9ad8-3bdf51c201f7" />

TCF + GPP + USPrivacy:
<img width="718" alt="Screenshot 2025-01-09 at 9 15 45 PM" src="https://github.com/user-attachments/assets/da0187d9-e084-49bf-a201-49e1254fa83d" />

GPP + USPrivacy:
<img width="566" alt="Screenshot 2025-01-09 at 9 16 21 PM" src="https://github.com/user-attachments/assets/98b5cd53-d765-449a-a284-b5b6fe8914a7" />

## Why is this change being made?

- [ ] Chore (non-functional changes)
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Tested by changing between jurisdictions having the privacy protocol combinations shown above, and then ensuring that the old keys are deleted

## Related issues

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.
