### PR TITLE
feat: add age band query params to iOS SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,15 @@ extension KetchUI {
         /// Inject CSS into the Ketch UI
         case css(String)
 
+        /// Exact age for age band legal basis resolution
+        case age(UInt)
+
+        /// Lower bound of age range for age band legal basis resolution
+        case ageLower(UInt)
+
+        /// Upper bound of age range for age band legal basis resolution
+        case ageUpper(UInt)
+
         public enum ExperienceToShow: String {
             case consent, preferences
         }

--- a/Sources/KetchSDK/UI/KetchUI.swift
+++ b/Sources/KetchSDK/UI/KetchUI.swift
@@ -234,7 +234,16 @@ extension KetchUI {
         
         /// Inject CSS into the Ketch UI
         case css(String)
-        
+
+        /// Exact age for age band legal basis resolution
+        case age(UInt)
+
+        /// Lower bound of age range for age band legal basis resolution
+        case ageLower(UInt)
+
+        /// Upper bound of age range for age band legal basis resolution
+        case ageUpper(UInt)
+
         public enum ExperienceToShow: String {
             case consent, preferences
         }
@@ -266,6 +275,12 @@ extension KetchUI {
             case (.preferencesTabs(_), .preferencesTabs(_)):
                 return true
             case (.ketchURL(_), .ketchURL(_)):
+                return true
+            case (.age(_), .age(_)):
+                return true
+            case (.ageLower(_), .ageLower(_)):
+                return true
+            case (.ageUpper(_), .ageUpper(_)):
                 return true
             default:
                 return false

--- a/Sources/KetchSDK/UI/PresentationItem/PresentationItem.swift
+++ b/Sources/KetchSDK/UI/PresentationItem/PresentationItem.swift
@@ -352,6 +352,15 @@ extension KetchUI.ExperienceOption {
             
         case .css(let string):
             return (key: "ketch_css_inject", value: string)
+
+        case .age(let value):
+            return (key: "ketch_age", value: String(value))
+
+        case .ageLower(let value):
+            return (key: "ketch_age_lower", value: String(value))
+
+        case .ageUpper(let value):
+            return (key: "ketch_age_upper", value: String(value))
         }
     }
 }


### PR DESCRIPTION
## Description of this change

> Adds age, ageLower, and ageUpper ExperienceOptions to the iOS SDK so ketch-tag can apply age-based legal basis overrides per purpose.
>
> - Added `.age(UInt)`, `.ageLower(UInt)`, `.ageUpper(UInt)` cases to `ExperienceOption` enum
> - Added `queryParameter` mappings for `ketch_age`, `ketch_age_lower`, `ketch_age_upper`
> - Updated README `Available Parameters` section with the three new cases

**ketch_age**
<img width="619" height="64" alt="Screenshot 2026-04-16 at 10 51 52 AM" src="https://github.com/user-attachments/assets/72010629-9341-4a1e-9e98-225d371fd9e4" />

**ketch_age_lower, ketch_age_upper**
<img width="620" height="76" alt="Screenshot 2026-04-16 at 10 52 54 AM" src="https://github.com/user-attachments/assets/b4b1a35e-26ae-414c-8299-04c0aad97266" />

## Why is this change being made?

- [ ] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

> Tested Locally:
>
> - Added `.age(25)` to the ketch-ios-sample app and confirmed `ketch_age=25` appears in WebView params log
> - Added `.ageLower(13)` and `.ageUpper(17)` and confirmed both appear in WebView params log
> - Verified params flow correctly into the ketch-tag WebView URL on simulator

## Related issues

[KD-17064](https://ketch-com.atlassian.net/browse/KD-17064)

## Checklist

- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Add screen recording ([learn how to](https://support.apple.com/guide/mac-help/take-a-screenshot-mh26782/mac))
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [x] I have informed stakeholders of my changes.

[KD-17064]: https://ketch-com.atlassian.net/browse/KD-17064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive change that only affects optional query parameter generation and documentation, with minimal impact on existing flows.
> 
> **Overview**
> Adds three new `KetchUI.ExperienceOption` values—`age`, `ageLower`, and `ageUpper`—to allow passing age/age-band information into the web experience.
> 
> Wires these options through option de-duplication (`Equatable`) and maps them to new webview query parameters (`ketch_age`, `ketch_age_lower`, `ketch_age_upper`), and updates the README to document the new parameters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c1a6d6beda5c5180a852e9e2ff92e424e25c02e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->