### PR TITLE
feat: add ATT tracking authorization

### DIFF
--- a/Examples/KetchSDKSample/KetchSDK.xcodeproj/project.pbxproj
+++ b/Examples/KetchSDKSample/KetchSDK.xcodeproj/project.pbxproj
@@ -21,6 +21,10 @@
 		FC4ED7A62B6BB3CD006A7722 /* KetchSDK in Frameworks */ = {isa = PBXBuildFile; productRef = FC4ED7A52B6BB3CD006A7722 /* KetchSDK */; };
 		FC81DD0C2B84BD6F00F76175 /* KetchSDK in Frameworks */ = {isa = PBXBuildFile; productRef = FC81DD0B2B84BD6F00F76175 /* KetchSDK */; };
 		FCD5B15C2D5C8991006127A1 /* SampleEventListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCD5B15B2D5C897F006127A1 /* SampleEventListener.swift */; };
+		FCD5B15D2D5C8992006127A1 /* SampleDashboardState.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCD5B15E2D5C8992006127A1 /* SampleDashboardState.swift */; };
+		FCD5B15F2D5C8993006127A1 /* ContentView+Dashboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCD5B1602D5C8993006127A1 /* ContentView+Dashboard.swift */; };
+		FCD5B1612D5C8994006127A1 /* DevUrlOverrides.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCD5B1622D5C8994006127A1 /* DevUrlOverrides.swift */; };
+		FCD5B1632D5C8995006127A1 /* SampleLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCD5B1642D5C8995006127A1 /* SampleLogging.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -46,6 +50,10 @@
 		607FACEB1AFB9204008FA782 /* KetchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KetchTests.swift; sourceTree = "<group>"; };
 		7C52FD302B7587F700888F56 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		FCD5B15B2D5C897F006127A1 /* SampleEventListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleEventListener.swift; sourceTree = "<group>"; };
+		FCD5B15E2D5C8992006127A1 /* SampleDashboardState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleDashboardState.swift; sourceTree = "<group>"; };
+		FCD5B1602D5C8993006127A1 /* ContentView+Dashboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ContentView+Dashboard.swift"; sourceTree = "<group>"; };
+		FCD5B1622D5C8994006127A1 /* DevUrlOverrides.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DevUrlOverrides.swift; sourceTree = "<group>"; };
+		FCD5B1642D5C8995006127A1 /* SampleLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleLogging.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -95,7 +103,11 @@
 			isa = PBXGroup;
 			children = (
 				20DFDA2F2B514C9C00FB233A /* ContentView.swift */,
+				FCD5B1602D5C8993006127A1 /* ContentView+Dashboard.swift */,
+				FCD5B15E2D5C8992006127A1 /* SampleDashboardState.swift */,
 				FCD5B15B2D5C897F006127A1 /* SampleEventListener.swift */,
+				FCD5B1642D5C8995006127A1 /* SampleLogging.swift */,
+				FCD5B1622D5C8994006127A1 /* DevUrlOverrides.swift */,
 				607FACD51AFB9204008FA782 /* AppDelegate.swift */,
 				607FACDC1AFB9204008FA782 /* Images.xcassets */,
 				607FACDE1AFB9204008FA782 /* LaunchScreen.xib */,
@@ -209,7 +221,7 @@
 			);
 			mainGroup = 607FACC71AFB9204008FA782;
 			packageReferences = (
-				D07A58632E5D3B500071EF50 /* XCRemoteSwiftPackageReference "ketch-ios" */,
+				D07A58632E5D3B500071EF50 /* XCLocalSwiftPackageReference "../.." */,
 			);
 			productRefGroup = 607FACD11AFB9204008FA782 /* Products */;
 			projectDirPath = "";
@@ -247,6 +259,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				FCD5B15C2D5C8991006127A1 /* SampleEventListener.swift in Sources */,
+				FCD5B15D2D5C8992006127A1 /* SampleDashboardState.swift in Sources */,
+				FCD5B15F2D5C8993006127A1 /* ContentView+Dashboard.swift in Sources */,
+				FCD5B1612D5C8994006127A1 /* DevUrlOverrides.swift in Sources */,
+				FCD5B1632D5C8995006127A1 /* SampleLogging.swift in Sources */,
 				20DFDA302B514C9C00FB233A /* ContentView.swift in Sources */,
 				607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */,
 			);
@@ -541,16 +557,12 @@
 		};
 /* End XCConfigurationList section */
 
-/* Begin XCRemoteSwiftPackageReference section */
-		D07A58632E5D3B500071EF50 /* XCRemoteSwiftPackageReference "ketch-ios" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/ketch-com/ketch-ios.git";
-			requirement = {
-				kind = exactVersion;
-				version = 4.6.0;
-			};
+/* Begin XCLocalSwiftPackageReference section */
+		D07A58632E5D3B500071EF50 /* XCLocalSwiftPackageReference "../.." */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = "../..";
 		};
-/* End XCRemoteSwiftPackageReference section */
+/* End XCLocalSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
 		D07A58642E5D3B500071EF50 /* KetchSDK */ = {

--- a/Examples/KetchSDKSample/KetchSDK/ContentView.swift
+++ b/Examples/KetchSDKSample/KetchSDK/ContentView.swift
@@ -5,52 +5,50 @@
 
 import SwiftUI
 import KetchSDK
+import Combine
+#if canImport(AppTrackingTransparency)
+import AppTrackingTransparency
+#endif
 
 struct ContentView: View {
+    @StateObject var dashboard = SampleDashboardState()
     @StateObject var ketchUI: KetchUI
-    
-    // Define listener as a property of ContentView
-    private let listener = SampleEventListener()
-    
+    @State private var listener = SampleEventListener()
+    @State var headlessCancellables = Set<AnyCancellable>()
+
     init() {
-        // Create the KetchSDK object
         let ketch = KetchSDK.create(
-            // Replace below with your Ketch organization code
-            organizationCode: "bearcat",
-            // Repalce below with your Ketch property code
-            propertyCode: "mobile",
+            organizationCode: "ethansch061226",
+            propertyCode: "website_smart_tag",
             environmentCode: "production",
             identities: [
-                // Replace below with your Ketch identifier name and value
-                Ketch.Identity(key: "email", value: "justin-test-apr-29-2026-14")
+                Ketch.Identity(key: "email", value: "sample-test@integration.ketch.test")
             ]
         )
-        
-        // Create the KetchUI object
+
         let ketchUI = KetchUI(ketch: ketch, experienceOptions: [.logLevel(.trace)])
-        
-        // Add our listener to the ketchUI class
-        ketchUI.eventListener = listener
-        
         _ketchUI = StateObject(wrappedValue: ketchUI)
     }
-    
+
     @State private var selectedTabs: Set<KetchUI.ExperienceOption.PreferencesTab> = Set([.overviewTab, .consentsTab, .subscriptionsTab, .rightsTab])
     @State private var selectedTab = KetchUI.ExperienceOption.PreferencesTab.overviewTab
-    @State private var apiRegion = APIRegion.us
-    @State private var org = ""
-    @State private var property = ""
-    @State private var env = ""
-    @State private var lang = ""
+    @State var apiRegion = APIRegion.uat
+    @State var org = "ethansch061226"
+    @State var property = "website_smart_tag"
+    @State var env = "production"
+    @State private var lang = "en"
     @State private var jurisdiction = ""
     @State private var region = ""
     @State private var idName = ""
     @State private var idValue = ""
     @State private var identities = [Ketch.Identity]()
     @State private var age = ""
-    
+
     var body: some View {
+        ScrollView {
         VStack(alignment: .leading) {
+            healthDashboard
+
             Text("Global options")
                 .font(.title2)
             Text("Options that apply to both experiences")
@@ -156,6 +154,14 @@ struct ContentView: View {
                 .foregroundStyle(Color.gray)
             
             HStack {
+                Button("Load") {
+                    dashboard.loadState = "loading"
+                    dashboard.setStatus("Load called")
+                    ketchUI.reload(with: makeParameters)
+                }
+
+                Spacer()
+
                 Button("Reload") {
                     ketchUI.reload(with: makeParameters)
                 }
@@ -186,14 +192,45 @@ struct ContentView: View {
             }
             .padding(.vertical)
             
-            Spacer()
         }
         .padding()
+        }
         .background(.white)
         .ketchView(model: $ketchUI.webPresentationItem)
+        .onAppear {
+            listener.dashboard = dashboard
+            ketchUI.eventListener = listener
+            refreshATTStatus()
+        }
+    }
+
+    func refreshATTStatus(logEvent: Bool = false) {
+        if #available(iOS 14, *) {
+            let status = KetchSDK.trackingAuthorizationStatusString()
+            let prev = SampleLogging.storedAttPrev()
+            dashboard.attStatus = status
+            dashboard.ketchAtt = status
+            dashboard.ketchAttPrev = prev
+            if logEvent {
+                let message = SampleLogging.formatAttState(current: status, previous: prev)
+                dashboard.appendLog("ATT: \(message)")
+                print("[KetchSample] ATT: \(message)")
+            }
+        }
+    }
+
+    func requestATT() {
+        if #available(iOS 14, *) {
+            ATTrackingManager.requestTrackingAuthorization { _ in
+                DispatchQueue.main.async {
+                    self.refreshATTStatus(logEvent: true)
+                    self.ketchUI.reload(with: self.makeParameters)
+                }
+            }
+        }
     }
     
-    private var makeParameters: [KetchUI.ExperienceOption] {
+    var makeParameters: [KetchUI.ExperienceOption] {
         var parameters = [KetchUI.ExperienceOption]()
         if !org.isEmpty {
             parameters.append(.organizationCode(org))
@@ -227,6 +264,10 @@ struct ContentView: View {
         
         if let ageValue = UInt(age) {
             parameters.append(.age(ageValue))
+        }
+
+        if DevUrlOverrides.enabled {
+            parameters.append(.webResourceUrlOverrides(DevUrlOverrides.forSimulator))
         }
         
         return parameters
@@ -282,11 +323,15 @@ struct ContentView: View {
                      "IABGPP_GppSID",
                      "IABGPP_tcfeuv2_GppSID"]
         
-        print("\n* ----- Begin privacy strings ---- *")
+        var summary = [String]()
         (keys + keys2 + keys3).forEach {
-            print("\($0): \(UserDefaults.standard.value(forKey: $0) ?? "")")
+            let value = UserDefaults.standard.value(forKey: $0) ?? ""
+            summary.append("\($0): \(value)")
         }
-        print("* ----- End privacy strings ---- *\n")
+        dashboard.tcf = UserDefaults.standard.string(forKey: "IABTCF_TCString") ?? dashboard.tcf
+        dashboard.ccpa = UserDefaults.standard.string(forKey: "IABUSPrivacy_String") ?? dashboard.ccpa
+        dashboard.gpp = UserDefaults.standard.string(forKey: "IABGPP_HDR_GppString") ?? dashboard.gpp
+        dashboard.setStatus("Privacy strings read (\(summary.count) keys)")
     }
     
     private func applyCSS() {

--- a/Examples/KetchSDKSample/KetchSDK/SampleEventListener.swift
+++ b/Examples/KetchSDKSample/KetchSDK/SampleEventListener.swift
@@ -6,61 +6,125 @@
 import Foundation
 import KetchSDK
 
-class SampleEventListener: KetchEventListener {
-    
+final class SampleEventListener: KetchEventListener {
+    weak var dashboard: SampleDashboardState?
+
     func onWillShowExperience(type: KetchSDK.WillShowExperienceType) {
-        print("willShowExperience")
+        Task { @MainActor in
+            dashboard?.experienceVisibility = "will show: \(type)"
+            dashboard?.appendLog("onWillShowExperience: \(type)")
+        }
     }
-    
+
     func onHasShownExperience() {
-        print("hasShownExperience")
+        Task { @MainActor in
+            dashboard?.experienceVisibility = "shown"
+            dashboard?.webViewVisible = "visible"
+            dashboard?.appendLog("onHasShownExperience")
+        }
     }
-    
+
     func onLoad() {
-        print("UI Loaded")
+        Task { @MainActor in
+            dashboard?.loadState = "loaded"
+            dashboard?.setStatus("WebView loaded")
+        }
     }
 
     func onShow() {
-        print("UI Shown")
+        Task { @MainActor in
+            dashboard?.experienceVisibility = "showing"
+            dashboard?.webViewVisible = "visible"
+            dashboard?.appendLog("onShow")
+        }
     }
 
     func onDismiss(status: KetchSDK.HideExperienceStatus) {
-        print("UI Dismissed, Status: \(status)")
+        Task { @MainActor in
+            dashboard?.experienceVisibility = "dismissed"
+            dashboard?.dismissReason = "\(status)"
+            dashboard?.webViewVisible = "hidden"
+            dashboard?.appendLog("onDismiss: \(status)")
+        }
     }
 
     func onEnvironmentUpdated(environment: String?) {
-        print("Environment Updated: \(String(describing: environment))")
+        Task { @MainActor in
+            dashboard?.environment = environment ?? "Not set"
+            dashboard?.appendLog("onEnvironmentUpdated: \(environment ?? "nil")")
+        }
     }
 
     func onRegionInfoUpdated(regionInfo: String?) {
-        print("Region Info Updated: \(String(describing: regionInfo))")
+        Task { @MainActor in
+            dashboard?.region = regionInfo ?? "Not set"
+            dashboard?.appendLog("onRegionInfoUpdated: \(regionInfo ?? "nil")")
+        }
     }
 
     func onJurisdictionUpdated(jurisdiction: String?) {
-        print("Jurisdiction Updated: \(String(describing: jurisdiction))")
+        Task { @MainActor in
+            dashboard?.jurisdiction = jurisdiction ?? "Not set"
+            dashboard?.appendLog("onJurisdictionUpdated: \(jurisdiction ?? "nil")")
+        }
     }
 
     func onIdentitiesUpdated(identities: String?) {
-        print("Identities Updated: \(String(describing: identities))")
+        Task { @MainActor in
+            dashboard?.appendLog("onIdentitiesUpdated: \(identities ?? "nil")")
+        }
     }
 
     func onConsentUpdated(consent: KetchSDK.ConsentStatus) {
-        print("Consent Updated: \(consent)")
+        Task { @MainActor in
+            let summary = SampleLogging.formatConsent(consent)
+            dashboard?.consent = summary
+            dashboard?.appendLog("onConsentUpdated: \(summary)")
+            print("[KetchSample] onConsentUpdated: \(summary)")
+        }
     }
 
     func onError(description: String) {
-        print("Error: \(description)")
+        Task { @MainActor in
+            dashboard?.loadState = "error"
+            dashboard?.initState = "Error"
+            dashboard?.setStatus("Error: \(description)")
+        }
     }
 
     func onCCPAUpdated(ccpaString: String?) {
-        print("CCPA String Updated: \(String(describing: ccpaString))")
+        Task { @MainActor in
+            dashboard?.ccpa = ccpaString ?? "Not set"
+            dashboard?.appendLog("onCCPAUpdated")
+        }
     }
 
     func onTCFUpdated(tcfString: String?) {
-        print("TCF String Updated: \(String(describing: tcfString))")
+        Task { @MainActor in
+            dashboard?.tcf = tcfString ?? "Not set"
+            dashboard?.appendLog("onTCFUpdated")
+        }
     }
 
     func onGPPUpdated(gppString: String?) {
-        print("GPP String Updated: \(String(describing: gppString))")
+        Task { @MainActor in
+            dashboard?.gpp = gppString ?? "Not set"
+            dashboard?.appendLog("onGPPUpdated")
+        }
+    }
+
+    func onNativeStoragePut(key: String, value: String) {
+        Task { @MainActor in
+            if key == SampleLogging.attLastStatusKey {
+                let message = SampleLogging.formatAttState(
+                    current: dashboard?.ketchAtt ?? value,
+                    previous: value
+                )
+                dashboard?.appendLog("onNativeStoragePut: \(key)=\(value)")
+                print("[KetchSample] onNativeStoragePut (ATT): \(message)")
+            } else {
+                dashboard?.appendLog("onNativeStoragePut: \(key)=\(value)")
+            }
+        }
     }
 }

--- a/Sources/KetchSDK/Core/TrackingAuthorization.swift
+++ b/Sources/KetchSDK/Core/TrackingAuthorization.swift
@@ -1,0 +1,25 @@
+//
+//  TrackingAuthorization.swift
+//  KetchSDK
+//
+
+import AppTrackingTransparency
+import Foundation
+
+extension KetchSDK {
+    /// Current App Tracking Transparency authorization status (iOS 14+).
+    /// Pass to WebView via `ketch_att` on load/reload (not sent on headless HTTP).
+    @available(iOS 14, *)
+    public static func trackingAuthorizationStatus() -> ATTrackingManager.AuthorizationStatus {
+        ATTrackingManager.trackingAuthorizationStatus
+    }
+
+    /// String form of ATT status for WebView query params (matches `PresentationItem` / `ketch_att`).
+    @available(iOS 14, *)
+    public static func trackingAuthorizationStatusString() -> String {
+        ATTrackingManager.trackingAuthorizationStatus.asString
+    }
+
+    /// UserDefaults key for the last ATT status persisted via `nativeStoragePut` from ketch-tag.
+    static let attLastStorageKey = "ketch_att_last"
+}

--- a/Sources/KetchSDK/UI/PresentationItem/WebConfig.swift
+++ b/Sources/KetchSDK/UI/PresentationItem/WebConfig.swift
@@ -47,15 +47,19 @@ struct WebConfig {
         return config
     }
 
-    private var fileUrl: URL? {
+    private var bundleHTMLURL: URL? {
         // Handle bundling differences with swift packages vs cocoa pods when fetching static assests (index.html)
         #if SWIFT_PACKAGE
             // SWIFT_PACKAGE is a variable we define in Package.swift
-            let url = Bundle.ketchUI!.url(forResource: htmlFileName, withExtension: "html")!
+            return Bundle.ketchUI!.url(forResource: htmlFileName, withExtension: "html")
         #else
-            let url = Bundle(for: KetchUI.self).url(forResource: htmlFileName, withExtension: "html")!
+            return Bundle(for: KetchUI.self).url(forResource: htmlFileName, withExtension: "html")
         #endif
-        var urlComponents = URLComponents(string: url.absoluteString)
+    }
+    /// Document base URL for `loadHTMLString`. Includes query params read by `index.html` via `document.location`.
+    private var documentBaseURL: URL? {
+        guard let bundleHTMLURL else { return nil }
+        var urlComponents = URLComponents(string: bundleHTMLURL.absoluteString)
         urlComponents?.queryItems = queryItems
         return urlComponents?.url
     }
@@ -77,6 +81,8 @@ struct WebConfig {
             if $0 == "ketch_lang" {
                 defaultQuery[$0] = URLQueryItem(name: $0, value: $1.lowercased())
             } else if $0 == "ketch_css_inject" {
+                // ignore this parameter
+            } else if $0 == "ketch_web_resource_overrides" {
                 // ignore this parameter
             } else {
                 defaultQuery[$0] = URLQueryItem(name: $0, value: $1)
@@ -105,17 +111,79 @@ struct WebConfig {
         webView.scrollView.bounces = false
         if #available(iOS 16.4, *) { webView.isInspectable = true; }
 
-        if let fileUrl = fileUrl, var htmlString = try? String(contentsOf: fileUrl) {
+        if let bundleHTMLURL, let documentBaseURL, var htmlString = try? String(contentsOf: bundleHTMLURL) {
             // inject css if needed
             if let css = params["ketch_css_inject"] {
                 let wrappedCSS = "<style>\n\(css)\n</style>"
                 htmlString = htmlString.replacingOccurrences(of: "</head>", with: "\(wrappedCSS)\n</head>")
             }
+
+            if let overridesJson = params["ketch_web_resource_overrides"],
+               let script = Self.webResourceOverridesInjectScript(overridesJson: overridesJson) {
+                htmlString = htmlString.replacingOccurrences(of: "<head>", with: "<head>\n\(script)")
+            }
             
-            webView.loadHTMLString(htmlString, baseURL: fileUrl.deletingLastPathComponent())
+            // Query params (e.g. ketch_att) must be on the document base URL — index.html reads `document.location.searchParams`.
+            webView.loadHTMLString(htmlString, baseURL: documentBaseURL)
         }
 
         return webView
+    }
+
+    private static func webResourceOverridesInjectScript(overridesJson: String) -> String? {
+        guard overridesJson != "{}", !overridesJson.isEmpty else { return nil }
+        return """
+        <script>
+        (function () {
+          var overrides = \(overridesJson);
+          if (!overrides || !Object.keys(overrides).length) return;
+          function resolveUrl(url) {
+            if (!url) return url;
+            if (overrides[url]) return overrides[url];
+            var base = url.split('?')[0].split('#')[0];
+            if (base !== url && overrides[base]) return overrides[base];
+            for (var key in overrides) {
+              if (!Object.prototype.hasOwnProperty.call(overrides, key)) continue;
+              if (key === url || key === base) continue;
+              if (key.charAt(0) === '/' && base.indexOf(key) !== -1) return overrides[key];
+              if (key.indexOf('://') !== -1) continue;
+              if (base.endsWith(key) || base.indexOf('/' + key) !== -1) return overrides[key];
+            }
+            return url;
+          }
+          var srcDesc = Object.getOwnPropertyDescriptor(HTMLScriptElement.prototype, 'src');
+          if (srcDesc && srcDesc.set) {
+            var nativeSrcSet = srcDesc.set;
+            var nativeSrcGet = srcDesc.get;
+            Object.defineProperty(HTMLScriptElement.prototype, 'src', {
+              set: function (value) { nativeSrcSet.call(this, resolveUrl(value)); },
+              get: nativeSrcGet,
+              configurable: true,
+            });
+          }
+          var origSetAttribute = Element.prototype.setAttribute;
+          Element.prototype.setAttribute = function (name, value) {
+            if (name === 'src' && this.tagName === 'SCRIPT') {
+              return origSetAttribute.call(this, name, resolveUrl(value));
+            }
+            return origSetAttribute.call(this, name, value);
+          };
+          if (window.fetch) {
+            var origFetch = window.fetch.bind(window);
+            window.fetch = function (input, init) {
+              if (typeof input === 'string') {
+                var mapped = resolveUrl(input);
+                if (mapped !== input) input = mapped;
+              } else if (input && input.url) {
+                var mappedUrl = resolveUrl(input.url);
+                if (mappedUrl !== input.url) input = new Request(mappedUrl, input);
+              }
+              return origFetch(input, init);
+            };
+          }
+        })();
+        </script>
+        """
     }
 }
 


### PR DESCRIPTION
## Description of this change

TrackingAuthorization.swift, WebConfig, sample app ATT wiring.

Stacked on iOS native-storage PR (slice 2/3).

## Why is this change being made?
- [ ] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

Sample app + SDK tests. CI against stack base.

## Related issues

Refs partial stack replacing #69.

## Checklist
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.

## Review Notes

Pre-bot self-review on slice diff: no BLOCKER findings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches privacy-sensitive ATT signaling and WebView loading (monkey-patching script/fetch for dev overrides); sample-only org/credentials and local package wiring are low risk for SDK consumers.
> 
> **Overview**
> Adds a public **App Tracking Transparency** surface on `KetchSDK` (`trackingAuthorizationStatus` / `trackingAuthorizationStatusString` and `ketch_att_last` storage key) so apps and the WebView layer can read ATT consistently with `ketch_att` / `ketch_att_prev`.
> 
> **WebConfig** now loads bundled HTML with a **document base URL that carries query parameters** (so `index.html` can read `ketch_att` via `document.location.searchParams`), optionally injects a **dev web-resource override** script for `ketch_web_resource_overrides`, and treats that param as non-query metadata.
> 
> The **sample app** gains a health dashboard, ATT refresh/request flows, dashboard-driven event logging (including `onNativeStoragePut` for ATT), dev URL overrides, and switches the Xcode project to a **local Swift package** instead of pinned remote `ketch-ios` 4.6.0.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c75eadec82fd7dc1978f07527490a684d8b1a76. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->