### PR TITLE
feat: add run-sample Cursor skills

### DIFF
--- a/.cursor/rules/development-workflow.mdc
+++ b/.cursor/rules/development-workflow.mdc
@@ -66,3 +66,34 @@ Before merging SDK changes:
 ## Simulator automation
 
 For CLI-driven taps, screenshots, and unified log capture without XCTest, see `.cursor/rules/ios-simulator-control.mdc`.
+
+## SDK Health Dashboard (manual QA)
+
+`Examples/KetchSDKSample` includes an on-screen **SDK Health Dashboard** so callbacks, ATT, WebView state, and headless CDN results are visible without reading the console.
+
+| Section | What to verify |
+| --- | --- |
+| **Connection** | Init state, status text, org/property/env (editable fields), API region |
+| **WebView / Experience** | Load state, visibility, dismiss reason, WebView visibility, `ketch_att` (iOS) |
+| **ATT (iOS)** | Native ATT status; **Request ATT** then **Reload WebView** updates `ketch_att` |
+| **Privacy / Consent** | Environment, jurisdiction, region, consent summary, US Privacy / TCF / GPP (truncated) |
+| **Headless** | **Fetch Location**, **Fetch Bootstrap**, **Cold Start** show inline OK/Error per step |
+| **Event log** | Timestamped callback trace (max ~50 lines) |
+
+Launch: `bash .cursor/skills/ketch-ios-run-sample/scripts/run-sample-app.sh local`
+
+Example org/property: `ethansch061226` / `website_smart_tag`. See `ketch-ios-run-sample` skill for prerequisites, launch, and smoke flow.
+
+Manual golden path: **Load** → structured fields populate → **Show Consent** → experience panel updates → (iOS) **Request ATT** → **Reload WebView** → headless **Fetch Bootstrap** shows success or error on-screen.
+
+## Local tag URL overrides (non-prod scripts)
+
+Use `.webResourceUrlOverrides([String: String])` on `KetchUI.ExperienceOption` to redirect exact CDN URLs to local dev servers. Separate from `ketchURL` / data center (boot.json path).
+
+```swift
+parameters.append(.webResourceUrlOverrides([
+    "https://cdn.uat.ketchjs.com/ketchtag/stable/v2.12/ketch-sdk.js": "http://localhost:9000/ketch-sdk.js",
+]))
+```
+
+WKWebView has no public subresource intercept; overrides are injected as an early `<script>` in index HTML. Sample: `DevUrlOverrides.enabled = true` in `DevUrlOverrides.swift`.

--- a/.cursor/skills/ketch-ios-run-sample/SKILL.md
+++ b/.cursor/skills/ketch-ios-run-sample/SKILL.md
@@ -27,6 +27,16 @@ bash .cursor/skills/ketch-ios-run-sample/scripts/run-sample-app.sh local
 
 The script boots a simulator when none is running, builds `KetchSDK-Example`, installs, streams unified logs for subsystem `com.ketch.sdk` (when the linked SDK supports it), and launches with `--console-pty`. Stop with `Ctrl-C`.
 
+## Manual testing basics
+
+**Needs:** macOS, Xcode, iOS Simulator (script boots one if none is running), network for CDN/headless steps.
+
+**Launch:** `bash .cursor/skills/ketch-ios-run-sample/scripts/run-sample-app.sh local` from the `ketch-ios` repo root. The sample app opens on the simulator.
+
+**In the app:** Scroll to **SDK Health Dashboard** at the top. Sample defaults use org `ethansch061226`, property `website_smart_tag`, environment `production` (fields are editable). Watch the dashboard panels and event log — you should not need Xcode console for a smoke pass.
+
+**Smoke flow:** **Load** → privacy/connection rows update → **Consent** or **Preferences** → WebView/Experience rows change → (iOS) **Request ATT** / **Reload WebView** if testing ATT → **Fetch Bootstrap** under Headless for CDN reachability. Failures appear inline on the dashboard or in the event log.
+
 ## Remote overrides
 
 ```bash
@@ -48,6 +58,19 @@ DEVICE_ID="<uuid>" bash .cursor/skills/ketch-ios-run-sample/scripts/run-sample-a
 bash .cursor/skills/ketch-ios-run-sample/scripts/run-sample-app.sh --build-only
 bash .cursor/skills/ketch-ios-run-sample/scripts/run-sample-app.sh --full-system-logs
 ```
+
+## Manual QA checklist (SDK Health Dashboard)
+
+After launch, verify on-screen panels in `KetchSDKSample` (no console required):
+
+1. **Connection** — Status shows initialized; org/property/env match editable fields (e.g. `ethansch061226` / `website_smart_tag` / `production`).
+2. **Load** — Tap **Load** (Actions) → Load row shows `loading` then `loaded`; environment/consent fields may update.
+3. **WebView / Experience** — Tap **Consent** → Visibility shows showing/dismissed; dismiss reason on dismiss.
+4. **ATT (iOS)** — **Request ATT** updates Native ATT; **Reload WebView** updates `ketch_att`.
+5. **Headless** — **Fetch Bootstrap** shows green `OK: N purpose(s)` or red `Error: …` inline.
+6. **Event log** — Callbacks append timestamped lines (capped at ~50).
+
+Optional: org with `plugins.att` for full lanyard ATT banner (not required for dashboard smoke).
 
 ## Notes
 


### PR DESCRIPTION
## Description of this change

Cursor skills and development-workflow rule documenting SDK Health Dashboard smoke flow (Load → Consent → ATT → Headless) with run scripts.

Independent PR off main (not stacked on SDK feature branches).

## Why is this change being made?
- [ ] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

Docs/scripts only — verify run-sample-app.sh executes against sample app.

## Related issues

N/A — DX tooling.

## Checklist
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.

## Review Notes

Pre-bot self-review on slice diff: no BLOCKER findings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only changes to Cursor rules/skills; no SDK or runtime behavior modified.
> 
> **Overview**
> Expands **Cursor DX docs** so reviewers and agents can run the sample app and verify SDK behavior on-screen instead of the Xcode console.
> 
> **`development-workflow.mdc`** adds an **SDK Health Dashboard (manual QA)** section (panel-by-panel expectations, launch via `run-sample-app.sh local`, golden path Load → Consent → ATT → Headless) and documents **`.webResourceUrlOverrides`** on `KetchUI.ExperienceOption` for local CDN script redirects (with a Swift example and `DevUrlOverrides` pointer).
> 
> **`ketch-ios-run-sample/SKILL.md`** adds **manual testing basics** (prereqs, default org/property/env, smoke flow) and a numbered **Manual QA checklist** aligned with Connection, Load, WebView/Experience, ATT, Headless, and event log.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9d6b4c8a31a6edecf9a1a7b9c6c33743ede4ca5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->