### PR TITLE
feat: add native storage bridge for WebView persistence

### DIFF
--- a/Sources/KetchSDK/Core/Ketch.swift
+++ b/Sources/KetchSDK/Core/Ketch.swift
@@ -31,7 +31,7 @@ public final class Ketch: ObservableObject {
     let propertyCode: String
     let environmentCode: String
     let identities: [Identity]
-    private let userDefaults: UserDefaults
+    private let nativeStorage: NativeStorage
     private var plugins = Set<PolicyPlugin>()
 
     private var configurationSubject = CurrentValueSubject<KetchSDK.Configuration?, KetchSDK.KetchError>(nil)
@@ -57,7 +57,7 @@ public final class Ketch: ObservableObject {
         self.propertyCode = propertyCode
         self.environmentCode = environmentCode
         self.identities = identities
-        self.userDefaults = userDefaults
+        self.nativeStorage = NativeStorage(userDefaults: userDefaults)
 
         configurationSubject
             .replaceError(with: nil)
@@ -420,18 +420,18 @@ private let PREFERENCE_VERSION = "preference_version"
 // MARK: - Internal interface for storage usage
 extension Ketch {
     func updateConsentVersion(version: Int?) {
-        userDefaults.set(version, forKey: CONSENT_VERSION)
+        nativeStorage.set(version, forKey: CONSENT_VERSION)
     }
 
     func getConsentVersion() -> Int? {
-        userDefaults.value(forKey: CONSENT_VERSION) as? Int
+        nativeStorage.value(forKey: CONSENT_VERSION) as? Int
     }
 
     func updatePreferenceVersion(version: Int?) {
-        userDefaults.set(version, forKey: PREFERENCE_VERSION)
+        nativeStorage.set(version, forKey: PREFERENCE_VERSION)
     }
 
     func getPreferenceVersion() -> Int? {
-        userDefaults.value(forKey: PREFERENCE_VERSION) as? Int
+        nativeStorage.value(forKey: PREFERENCE_VERSION) as? Int
     }
 }

--- a/Sources/KetchSDK/Core/NativeStorage.swift
+++ b/Sources/KetchSDK/Core/NativeStorage.swift
@@ -20,4 +20,30 @@ struct NativeStorage {
     func write(key: String, value: String) {
         userDefaults.set(value, forKey: key)
     }
+
+    // MARK: - Generic value access (mirrors UserDefaults set/value)
+
+    func set(_ value: Any?, forKey key: String) {
+        userDefaults.set(value, forKey: key)
+    }
+
+    func value(forKey key: String) -> Any? {
+        userDefaults.value(forKey: key)
+    }
+
+    // MARK: - Removal
+
+    func removeObject(forKey key: String) {
+        userDefaults.removeObject(forKey: key)
+    }
+
+    /// Removes every stored key whose name begins with one of `prefixes`. Returns the count removed.
+    @discardableResult
+    func removeValues(withPrefixes prefixes: [String]) -> Int {
+        let keys = userDefaults.dictionaryRepresentation().keys.filter { key in
+            prefixes.contains { key.hasPrefix($0) }
+        }
+        keys.forEach { userDefaults.removeObject(forKey: $0) }
+        return keys.count
+    }
 }

--- a/Sources/KetchSDK/Core/NativeStorage.swift
+++ b/Sources/KetchSDK/Core/NativeStorage.swift
@@ -1,0 +1,23 @@
+//
+//  NativeStorage.swift
+//  KetchSDK
+//
+
+import Foundation
+
+/// String key/value persistence backed by UserDefaults, written via the `nativeStoragePut` bridge event.
+struct NativeStorage {
+    private let userDefaults: UserDefaults
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+    }
+
+    func read(key: String, defaultValue: String = "") -> String {
+        userDefaults.string(forKey: key) ?? defaultValue
+    }
+
+    func write(key: String, value: String) {
+        userDefaults.set(value, forKey: key)
+    }
+}

--- a/Sources/KetchSDK/Core/PolicyProtocol.swift
+++ b/Sources/KetchSDK/Core/PolicyProtocol.swift
@@ -61,17 +61,19 @@ open class PolicyPlugin: PolicyProtocol {
     var configuration: KetchSDK.Configuration?
 
     let userDefaults: UserDefaults
+    private let nativeStorage: NativeStorage
 
     public init(userDefaults: UserDefaults = .standard) {
         self.userDefaults = userDefaults
+        self.nativeStorage = NativeStorage(userDefaults: userDefaults)
     }
 
     func save(_ value: Any?, forKey key: String) {
-        userDefaults.set(value, forKey: key)
+        nativeStorage.set(value, forKey: key)
     }
 
     func getValue(withKey key: String) -> Any? {
-        userDefaults.value(forKey: key)
+        nativeStorage.value(forKey: key)
     }
 
     // MARK: - PolicyProtocol

--- a/Sources/KetchSDK/UI/KetchUI.swift
+++ b/Sources/KetchSDK/UI/KetchUI.swift
@@ -116,6 +116,9 @@ public final class KetchUI: ObservableObject {
             
         case .onConsentUpdated(let consent):
             eventListener?.onConsentUpdated(consent: consent)
+
+        case .nativeStoragePut(let key, let value):
+            eventListener?.onNativeStoragePut(key: key, value: value)
             
         case .error(let description):
             eventListener?.onError(description: description)
@@ -320,4 +323,8 @@ public protocol KetchEventListener: AnyObject {
     func onCCPAUpdated(ccpaString: String?)
     func onTCFUpdated(tcfString: String?)
     func onGPPUpdated(gppString: String?)
+}
+
+public extension KetchEventListener {
+    func onNativeStoragePut(key: String, value: String) {}
 }

--- a/Sources/KetchSDK/UI/PresentationItem/PresentationItem.swift
+++ b/Sources/KetchSDK/UI/PresentationItem/PresentationItem.swift
@@ -22,6 +22,7 @@ extension KetchUI {
             case onTCFUpdated(String?)
             case onGPPUpdated(String?)
             case onConsentUpdated(consent: KetchSDK.ConsentStatus)
+            case nativeStoragePut(key: String, value: String)
             case error(description: String)
             case tapOutside
             case environment(String?)
@@ -40,6 +41,7 @@ extension KetchUI {
         let config: WebConfig
         let onEvent: ((Event) -> Void)?
         private let userDefaults: UserDefaults = .standard
+        private let nativeStorage = NativeStorage()
         private var configuration: KetchSDK.Configuration?
         private let webNavigationHandler = WebNavigationHandler()
         
@@ -269,6 +271,14 @@ extension KetchUI {
             case .identities:
                 KetchLogger.log.debug("webView onEvent: \(event.rawValue): \((body as? String) ?? "unknown")")
                 onEvent?(.identities(body as? String))
+            case .nativeStoragePut:
+                guard let payload: NativeStoragePutPayload = payload(with: body) else {
+                    KetchLogger.log.error("Failed to parse nativeStoragePut payload")
+                    return
+                }
+                KetchLogger.log.debug("nativeStoragePut: \(payload.key)=\(payload.value)")
+                nativeStorage.write(key: payload.key, value: payload.value)
+                onEvent?(.nativeStoragePut(key: payload.key, value: payload.value))
             default:
                 break;
             }
@@ -384,6 +394,7 @@ class WebHandler: NSObject, WKScriptMessageHandler {
         case error
         case tapOutside
         case geoip
+        case nativeStoragePut = "nativeStoragePut"
 
     }
     
@@ -401,6 +412,11 @@ class WebHandler: NSObject, WKScriptMessageHandler {
         
         onEvent?(event, message.body)
     }
+}
+
+private struct NativeStoragePutPayload: Decodable {
+    let key: String
+    let value: String
 }
 
 private struct ConsentModel: Codable {

--- a/Sources/KetchSDK/UI/PresentationItem/PresentationItem.swift
+++ b/Sources/KetchSDK/UI/PresentationItem/PresentationItem.swift
@@ -40,7 +40,6 @@ extension KetchUI {
         let item: WebExperienceItem
         let config: WebConfig
         let onEvent: ((Event) -> Void)?
-        private let userDefaults: UserDefaults = .standard
         private let nativeStorage = NativeStorage()
         private var configuration: KetchSDK.Configuration?
         private let webNavigationHandler = WebNavigationHandler()
@@ -135,15 +134,8 @@ extension KetchUI {
         
         // Utility function to clear keys with specified prefixes
         private func clearKeysWithPrefixes() {
-            let keysToRemove = userDefaults.dictionaryRepresentation().keys.filter { key in
-                WebPresentationItem.prefixesToRemove.contains { prefix in key.hasPrefix(prefix) }
-            }
-            
-            keysToRemove.forEach { key in
-                userDefaults.removeObject(forKey: key)
-            }
-            
-            KetchLogger.log.debug("Cleared \(keysToRemove.count) keys with prefixes \(WebPresentationItem.prefixesToRemove)")
+            let count = nativeStorage.removeValues(withPrefixes: WebPresentationItem.prefixesToRemove)
+            KetchLogger.log.debug("Cleared \(count) keys with prefixes \(WebPresentationItem.prefixesToRemove)")
         }
         
         private func webExperience(orgCode: String,
@@ -302,7 +294,7 @@ extension KetchUI {
 
             // Save privacy strings to UserDefaults
             privacyStrings.forEach { pair in
-                userDefaults.set(pair.value, forKey: pair.key)
+                nativeStorage.set(pair.value, forKey: pair.key)
             }
 
             // Log the number of keys saved and the privacy type

--- a/Tests/KetchSDKTests/NativeStorageTests.swift
+++ b/Tests/KetchSDKTests/NativeStorageTests.swift
@@ -1,0 +1,38 @@
+//
+//  NativeStorageTests.swift
+//  KetchSDKTests
+//
+
+import XCTest
+@testable import KetchSDK
+
+final class NativeStorageTests: XCTestCase {
+    private var userDefaults: UserDefaults!
+    private var suiteName: String!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "NativeStorageTests.\(UUID().uuidString)"
+        userDefaults = UserDefaults(suiteName: suiteName)!
+    }
+
+    override func tearDown() {
+        if let suiteName {
+            userDefaults.removePersistentDomain(forName: suiteName)
+        }
+        userDefaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    func testReadReturnsDefaultWhenKeyMissing() {
+        let storage = NativeStorage(userDefaults: userDefaults)
+        XCTAssertEqual(storage.read(key: "missing", defaultValue: "notDetermined"), "notDetermined")
+    }
+
+    func testWriteAndReadRoundTrip() {
+        let storage = NativeStorage(userDefaults: userDefaults)
+        storage.write(key: "sample_key", value: "sample_value")
+        XCTAssertEqual(storage.read(key: "sample_key", defaultValue: ""), "sample_value")
+    }
+}

--- a/Tests/KetchSDKTests/NativeStorageTests.swift
+++ b/Tests/KetchSDKTests/NativeStorageTests.swift
@@ -35,4 +35,38 @@ final class NativeStorageTests: XCTestCase {
         storage.write(key: "sample_key", value: "sample_value")
         XCTAssertEqual(storage.read(key: "sample_key", defaultValue: ""), "sample_value")
     }
+
+    func testSetAndValueRoundTripForInt() {
+        let storage = NativeStorage(userDefaults: userDefaults)
+        storage.set(42, forKey: "consent_version")
+        XCTAssertEqual(storage.value(forKey: "consent_version") as? Int, 42)
+    }
+
+    func testSetNilRemovesValue() {
+        let storage = NativeStorage(userDefaults: userDefaults)
+        storage.set(7, forKey: "some_key")
+        storage.set(nil, forKey: "some_key")
+        XCTAssertNil(storage.value(forKey: "some_key"))
+    }
+
+    func testRemoveObjectDeletesKey() {
+        let storage = NativeStorage(userDefaults: userDefaults)
+        storage.write(key: "to_remove", value: "bye")
+        storage.removeObject(forKey: "to_remove")
+        XCTAssertEqual(storage.read(key: "to_remove", defaultValue: "gone"), "gone")
+    }
+
+    func testRemoveValuesWithPrefixesOnlyRemovesMatching() {
+        let storage = NativeStorage(userDefaults: userDefaults)
+        storage.write(key: "IABTCF_TCString", value: "abc")
+        storage.write(key: "IABGPP_HDR_Version", value: "1")
+        storage.write(key: "keep_me", value: "safe")
+
+        let removed = storage.removeValues(withPrefixes: ["IABTCF", "IABGPP", "IABUS"])
+
+        XCTAssertEqual(removed, 2)
+        XCTAssertEqual(storage.read(key: "IABTCF_TCString", defaultValue: "missing"), "missing")
+        XCTAssertEqual(storage.read(key: "IABGPP_HDR_Version", defaultValue: "missing"), "missing")
+        XCTAssertEqual(storage.read(key: "keep_me", defaultValue: "missing"), "safe")
+    }
 }


### PR DESCRIPTION
## Description of this change

Introduce `NativeStorage` (UserDefaults-backed read/write) and wire the `nativeStoragePut` web bridge event through `PresentationItem` and `KetchEventListener`.

## Why is this change being made?

- [ ] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

- `xcodebuild -scheme KetchSDK -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build test`
- `NativeStorageTests` (read default, write/read round-trip)

## Related issues

[KD-17455](https://ketch-com.atlassian.net/browse/KD-17455), base for #75

## Checklist

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.

[KD-17455]: https://ketch-com.atlassian.net/browse/KD-17455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The WebView bridge can write arbitrary keys into app `UserDefaults` alongside consent/IAB data; behavior matches existing privacy-string persistence but expands who can trigger writes.
> 
> **Overview**
> Adds a **`NativeStorage`** wrapper around `UserDefaults` and routes existing consent/version and policy-plugin persistence through it instead of calling `UserDefaults` directly.
> 
> The Web experience can now persist string key/value pairs via a **`nativeStoragePut`** script message: **`PresentationItem`** decodes the payload, writes with `nativeStorage.write`, and surfaces a **`nativeStoragePut`** UI event. **`KetchUI`** forwards that to **`KetchEventListener`** through a new optional **`onNativeStoragePut`** hook (default no-op). IAB prefix cleanup on WebView load/reload uses **`removeValues(withPrefixes:)`** instead of inline `UserDefaults` scanning.
> 
> **`NativeStorageTests`** cover read/write, typed values, removal, and prefix-based deletes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6461dc67c210036afd0d356ac288acf14c52c295. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->