### PR TITLE
chore: ignore xcode-build-server artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,7 @@ Framework/.DS_Store
 # Python (Cursor skills / tooling)
 __pycache__/
 *.pyc
+
+# SourceKit-LSP build server (xcode-build-server) — machine-specific paths
+buildServer.json
+.compile


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Code generated by shipbuilder init 1.21.3. DO NOT EDIT. -->

## Description of this change

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

Adds xcode-build-server artifacts to `.gitignore`. No source changes.

Part 1/9 of the split of #76 into a stacked, reviewable series (`mobile-sdk-roadmap.md` §1-§2.1). Landed first, on its own, as the mechanic proof for the stack before the remaining 8 layers were built on top.

## Why is this change being made?

- [x] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

`xcodebuild -scheme KetchSDK -destination 'generic/platform=iOS Simulator' build` — succeeded. No test-target changes at this layer.

## Related issues

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Refs #76 — layer 1 of 9 in the split of #76.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.