### PR TITLE
fix: deliver onNativeStoragePut to KetchEventListener conformers

### DIFF
--- a/Sources/KetchSDK/UI/KetchUI.swift
+++ b/Sources/KetchSDK/UI/KetchUI.swift
@@ -328,6 +328,7 @@ public protocol KetchEventListener: AnyObject {
     func onCCPAUpdated(ccpaString: String?)
     func onTCFUpdated(tcfString: String?)
     func onGPPUpdated(gppString: String?)
+    func onNativeStoragePut(key: String, value: String)
 }
 
 public extension KetchEventListener {

--- a/Tests/KetchSDKTests/KetchEventListenerDispatchTests.swift
+++ b/Tests/KetchSDKTests/KetchEventListenerDispatchTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+@testable import KetchSDK
+
+final class KetchEventListenerDispatchTests: XCTestCase {
+
+    /// `KetchUI` stores its listener as `KetchEventListener?` and calls
+    /// `onNativeStoragePut` through that existential. A member declared only in a
+    /// protocol extension dispatches statically there, so the empty default body runs
+    /// and the conformer's implementation is skipped without any compiler diagnostic.
+    /// Calling through the existential — rather than through `SpyEventListener` — is
+    /// what makes this test able to catch that.
+    func testNativeStoragePutReachesConformerThroughExistential() {
+        let spy = SpyEventListener()
+        let listener: KetchEventListener? = spy
+
+        listener?.onNativeStoragePut(key: "IABTCF_TCString", value: "CPabc123")
+
+        XCTAssertEqual(spy.nativeStoragePuts.count, 1)
+        XCTAssertEqual(spy.nativeStoragePuts.first?.key, "IABTCF_TCString")
+        XCTAssertEqual(spy.nativeStoragePuts.first?.value, "CPabc123")
+    }
+
+    /// The extension default keeps `onNativeStoragePut` optional for conformers.
+    /// `MinimalEventListener` omits it, so this file failing to compile is the
+    /// assertion; the call confirms the default is reachable and inert at runtime.
+    func testConformerOmittingNativeStoragePutStillCompilesAndNoOps() {
+        let listener: KetchEventListener? = MinimalEventListener()
+
+        listener?.onNativeStoragePut(key: "key", value: "value")
+    }
+}
+
+// MARK: - Test doubles
+
+private final class SpyEventListener: KetchEventListener {
+    private(set) var nativeStoragePuts: [(key: String, value: String)] = []
+
+    func onNativeStoragePut(key: String, value: String) {
+        nativeStoragePuts.append((key: key, value: value))
+    }
+
+    func onShow() { }
+    func onWillShowExperience(type: KetchSDK.WillShowExperienceType) { }
+    func onHasShownExperience() { }
+    func onDismiss(status: KetchSDK.HideExperienceStatus) { }
+    func onEnvironmentUpdated(environment: String?) { }
+    func onRegionInfoUpdated(regionInfo: String?) { }
+    func onJurisdictionUpdated(jurisdiction: String?) { }
+    func onIdentitiesUpdated(identities: String?) { }
+    func onConsentUpdated(consent: KetchSDK.ConsentStatus) { }
+    func onError(description: String) { }
+    func onCCPAUpdated(ccpaString: String?) { }
+    func onTCFUpdated(tcfString: String?) { }
+    func onGPPUpdated(gppString: String?) { }
+}
+
+/// Deliberately does not implement `onNativeStoragePut`.
+private final class MinimalEventListener: KetchEventListener {
+    func onShow() { }
+    func onWillShowExperience(type: KetchSDK.WillShowExperienceType) { }
+    func onHasShownExperience() { }
+    func onDismiss(status: KetchSDK.HideExperienceStatus) { }
+    func onEnvironmentUpdated(environment: String?) { }
+    func onRegionInfoUpdated(regionInfo: String?) { }
+    func onJurisdictionUpdated(jurisdiction: String?) { }
+    func onIdentitiesUpdated(identities: String?) { }
+    func onConsentUpdated(consent: KetchSDK.ConsentStatus) { }
+    func onError(description: String) { }
+    func onCCPAUpdated(ccpaString: String?) { }
+    func onTCFUpdated(tcfString: String?) { }
+    func onGPPUpdated(gppString: String?) { }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Code generated by shipbuilder init 1.21.3. DO NOT EDIT. -->

## Description of this change

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

Dispatches `onNativeStoragePut` to registered `KetchEventListener` conformers — the one hunk of `KetchUI.swift` not owned by a later layer — plus its test coverage (`KetchEventListenerDispatchTests.swift`).

Part 2/9 of the split of #76.

## Why is this change being made?

- [ ] Chore (non-functional changes)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

`xcodebuild -scheme KetchSDK -destination 'generic/platform=iOS Simulator' build` — succeeded. New `KetchEventListenerDispatchTests.swift` runs as part of the full suite verified at the top of the stack (#87): 71/71 passed.

## Related issues

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Refs #76 — layer 2 of 9 in the split of #76.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.