### PR TITLE
feat: migrate consent API to static methods

### DIFF
--- a/Sources/KetchSDK/Core/KetchSDK.swift
+++ b/Sources/KetchSDK/Core/KetchSDK.swift
@@ -4,6 +4,7 @@
 //
 
 import Combine
+import Foundation
 
 public enum KetchSDK {
     /// Instantiation of Ketch core class
@@ -12,129 +13,207 @@ public enum KetchSDK {
     ///   - propertyCode: Property defined in the platform side.
     ///   - environmentCode: Environment defined in the platform side.
     ///   - identities: Identifiers of current instance of app. Possible types defined in the platform side. For iOS it is usually "idfa" (AdvertisementIdentifier)
+    ///   - dataCenter: CDN region for headless API calls (defaults to US).
     /// - Returns: Ketch instance.
     public static func create(
         organizationCode: String,
         propertyCode: String,
         environmentCode: String,
-        identities: [Ketch.Identity]
+        identities: [Ketch.Identity],
+        dataCenter: KetchDataCenter = .us
     ) -> Ketch {
         Ketch(
             organizationCode: organizationCode,
             propertyCode: propertyCode,
             environmentCode: environmentCode,
-            identities: identities
+            identities: identities,
+            dataCenter: dataCenter
         )
     }
 }
 
+// MARK: - Headless API (static, web/v3)
+
+extension KetchSDK {
+    /// Combined ISO region code (e.g. "US-CA") from GeoIP (`GET /ip`).
+    public static func getRegion(
+        dataCenter: KetchDataCenter = .us
+    ) -> AnyPublisher<String?, KetchError> {
+        KetchApiRequest(dataCenter: dataCenter).getLocation()
+            .map { $0.location?.toRegionCode() }
+            .eraseToAnyPublisher()
+    }
+
+    /// Minimal config (`GET .../boot.json`).
+    public static func getBootstrapConfiguration(
+        organization: String,
+        property: String,
+        dataCenter: KetchDataCenter = .us
+    ) -> AnyPublisher<Configuration, KetchError> {
+        KetchApiRequest(dataCenter: dataCenter)
+            .getBootstrapConfiguration(organization: organization, property: property)
+    }
+
+    /// Full config with optional env / jurisdiction / language and hash query param.
+    public static func getFullConfiguration(
+        request: FullConfigurationRequest,
+        dataCenter: KetchDataCenter = .us
+    ) -> AnyPublisher<Configuration, KetchError> {
+        KetchApiRequest(dataCenter: dataCenter).getFullConfiguration(request: request)
+    }
+
+    /// Resolved jurisdiction code from full config (`GET .../config.json`).
+    public static func getJurisdiction(
+        request: FullConfigurationRequest,
+        dataCenter: KetchDataCenter = .us
+    ) -> AnyPublisher<String?, KetchError> {
+        KetchApiRequest(dataCenter: dataCenter).getFullConfiguration(request: request)
+            .map { $0.jurisdictionCode() }
+            .eraseToAnyPublisher()
+    }
+
+    /// Server consent including `protocols` (`POST .../consent/{org}/get`).
+    public static func getConsent(
+        config: ConsentConfig,
+        dataCenter: KetchDataCenter = .us
+    ) -> AnyPublisher<ConsentStatus, KetchError> {
+        KetchApiRequest(dataCenter: dataCenter).getConsent(config: config)
+    }
+
+    /// Updates consent; returns server response with computed `protocols`. Does not send `protocols` in the request body.
+    public static func setConsent(
+        update: ConsentUpdate,
+        dataCenter: KetchDataCenter = .us
+    ) -> AnyPublisher<ConsentStatus, KetchError> {
+        KetchApiRequest(dataCenter: dataCenter).setConsent(update: headlessUpdate(from: update))
+    }
+
+    private static func headlessUpdate(from update: ConsentUpdate) -> ConsentUpdate {
+        ConsentUpdate(
+            organizationCode: update.organizationCode,
+            propertyCode: update.propertyCode,
+            environmentCode: update.environmentCode,
+            identities: update.identities,
+            jurisdictionCode: update.jurisdictionCode,
+            migrationOption: update.migrationOption,
+            purposes: update.purposes,
+            vendors: update.vendors,
+            protocols: update.protocols
+        )
+    }
+
+    /// Invokes a data subject right (`POST .../rights/{org}/invoke`).
+    public static func invokeRight(
+        request: InvokeRightRequest,
+        dataCenter: KetchDataCenter = .us
+    ) -> AnyPublisher<Void, KetchError> {
+        KetchApiRequest(dataCenter: dataCenter).invokeRight(request: request)
+    }
+
+    /// Gets subscription topics/controls (`POST .../subscriptions/{org}/get`).
+    public static func getSubscriptions(
+        request: SubscriptionsRequest,
+        dataCenter: KetchDataCenter = .us
+    ) -> AnyPublisher<SubscriptionsResponse, KetchError> {
+        KetchApiRequest(dataCenter: dataCenter).getSubscriptions(request: request)
+    }
+
+    /// Updates subscription topics/controls (`POST .../subscriptions/{org}/update`).
+    public static func setSubscriptions(
+        request: SubscriptionsRequest,
+        dataCenter: KetchDataCenter = .us
+    ) -> AnyPublisher<Void, KetchError> {
+        KetchApiRequest(dataCenter: dataCenter).setSubscriptions(request: request)
+    }
+
+    public static func getPreferenceQRUrl(
+        request: PreferenceQRRequest,
+        dataCenter: KetchDataCenter = .us
+    ) -> URL? {
+        HeadlessApiClient(dataCenter: dataCenter).getPreferenceQRUrl(request: request)
+    }
+}
+
+// MARK: - Legacy static publishers
+
 extension KetchSDK {
     /// Retrieves full organization configuration data.
-    /// - Parameters:
-    ///   - organization: organization code
-    ///   - property: property code
-    /// - Returns: Publisher of organization configuration request result.
-    public func config(
+    public static func config(
         organization: String,
-        property: String
+        property: String,
+        dataCenter: KetchDataCenter = .us
     ) -> AnyPublisher<Configuration, KetchError> {
-        KetchApiRequest()
+        KetchApiRequest(dataCenter: dataCenter)
             .fetchConfig(organization: organization, property: property)
-            .eraseToAnyPublisher()
     }
 
-    /// Retrieves currently set consent status.
-    /// - Parameters:
-    ///   - organizationCode: organization code
-    ///   - propertyCode: property code
-    ///   - environmentCode: environment code
-    ///   - jurisdictionCode: jurisdiction code
-    ///   - identities: map of identity code and value
-    ///   - purposes: map of purpose code and PurposeLegalBasis
-    /// - Returns: Publisher of set consent request result.
-    public func getConsent(
+    /// Retrieves currently set consent status from the CDN.
+    public static func getConsent(
         organizationCode: String,
         propertyCode: String,
         environmentCode: String,
         jurisdictionCode: String,
-        identities: [String : String],
-        purposes: [String : ConsentConfig.PurposeLegalBasis]
+        identities: [String: String],
+        purposes: [String: ConsentConfig.PurposeLegalBasis],
+        dataCenter: KetchDataCenter = .us
     ) -> AnyPublisher<ConsentStatus, KetchError> {
-        KetchApiRequest()
-            .getConsent(
-                config: ConsentConfig(
-                    organizationCode: organizationCode,
-                    propertyCode: propertyCode,
-                    environmentCode: environmentCode,
-                    jurisdictionCode: jurisdictionCode,
-                    identities: identities,
-                    purposes: purposes
-                )
-            )
-            .eraseToAnyPublisher()
+        getConsent(
+            config: ConsentConfig(
+                organizationCode: organizationCode,
+                propertyCode: propertyCode,
+                environmentCode: environmentCode,
+                jurisdictionCode: jurisdictionCode,
+                identities: identities,
+                purposes: purposes
+            ),
+            dataCenter: dataCenter
+        )
     }
 
-    /// Sends a request for updating consent status
-    /// - Parameters:
-    ///   - organizationCode: organization code
-    ///   - propertyCode: property code
-    ///   - environmentCode: environment code
-    ///   - identities: map of identity code and value
-    ///   - jurisdictionCode: jurisdiction code
-    ///   - migrationOption: migration option.
-    ///   - purposes: map of purpose code and PurposeLegalBasis
-    ///   - vendors: list of vendors
-    /// - Returns: Publisher of get consent request result.
-    public func setConsent(
+    /// Sends a request for updating consent status; completes when the CDN accepts the update.
+    public static func setConsent(
         organizationCode: String,
         propertyCode: String,
         environmentCode: String,
-        identities: [String : String],
+        identities: [String: String],
         jurisdictionCode: String,
         migrationOption: ConsentUpdate.MigrationOption,
-        purposes: [String : ConsentUpdate.PurposeAllowedLegalBasis],
+        purposes: [String: ConsentUpdate.PurposeAllowedLegalBasis],
         vendors: [String]?,
-        protocols: [String: String]?
+        protocols: [String: String]?,
+        dataCenter: KetchDataCenter = .us
     ) -> AnyPublisher<Void, KetchError> {
-        KetchApiRequest()
-            .updateConsent(
-                update: ConsentUpdate(
-                    organizationCode: organizationCode,
-                    propertyCode: propertyCode,
-                    environmentCode: environmentCode,
-                    identities: identities,
-                    jurisdictionCode: jurisdictionCode,
-                    migrationOption: migrationOption,
-                    purposes: purposes,
-                    vendors: vendors,
-                    protocols: protocols
-                )
-            )
-            .eraseToAnyPublisher()
+        setConsent(
+            update: ConsentUpdate(
+                organizationCode: organizationCode,
+                propertyCode: propertyCode,
+                environmentCode: environmentCode,
+                identities: identities,
+                jurisdictionCode: jurisdictionCode,
+                migrationOption: migrationOption,
+                purposes: purposes,
+                vendors: vendors,
+                protocols: protocols
+            ),
+            dataCenter: dataCenter
+        )
+        .map { _ in () }
+        .eraseToAnyPublisher()
     }
 
     /// Invokes the specified rights.
-    /// - Parameters:
-    ///   - organizationCode: organization code
-    ///   - propertyCode: property code
-    ///   - environmentCode: environment code
-    ///   - identities: jurisdiction code
-    ///   - invokedAt: the current time
-    ///   - jurisdictionCode: map of identity code and value
-    ///   - rightCode: right code
-    ///   - user: current user object
-    /// - Returns: Publisher of invoke rights request result.
-    public func invokeRights(
+    public static func invokeRights(
         organizationCode: String,
         propertyCode: String,
         environmentCode: String,
-        identities: [String : String],
+        identities: [String: String],
         invokedAt: Int?,
         jurisdictionCode: String,
         rightCode: String,
-        user: InvokeRightConfig.User
+        user: InvokeRightConfig.User,
+        dataCenter: KetchDataCenter = .us
     ) -> AnyPublisher<Void, KetchError> {
-        KetchApiRequest()
+        KetchApiRequest(dataCenter: dataCenter)
             .invokeRights(
                 organization: organizationCode,
                 config: InvokeRightConfig(
@@ -147,15 +226,13 @@ extension KetchSDK {
                     user: user
                 )
             )
-            .eraseToAnyPublisher()
     }
 
-    /// Retrieves list of consents vendors.
-    /// - Returns: Publisher of getVendors request result.
-    public func getVendors() -> AnyPublisher<Vendors, KetchError> {
-        KetchApiRequest()
-            .getVendors()
-            .eraseToAnyPublisher()
+    /// Retrieves list of consent vendors.
+    public static func getVendors(
+        dataCenter: KetchDataCenter = .us
+    ) -> AnyPublisher<Vendors, KetchError> {
+        KetchApiRequest(dataCenter: dataCenter).getVendors()
     }
 }
 
@@ -166,6 +243,7 @@ extension KetchSDK {
         case Close = "close"
         case CloseWithoutSettingConsent = "closeWithoutSettingConsent"
         case WillNotShow = "willNotShow"
+        case SetSubscriptions = "setSubscriptions"
         case None = "none"
     }
     


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Code generated by shipbuilder init 1.21.3. DO NOT EDIT. -->

## Description of this change

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

Migrates `KetchSDK`'s static consent/rights surface onto the new headless API client from #81 (whole-file rewrite of `KetchSDK.swift`). Breaking change to the static API.

Pulled forward from where the original PR's diff would place this: `KetchSDK.swift` on `main` calls `KetchApiRequest().updateConsent(...)`, renamed to `setConsent` in #81 — without this layer landing immediately after, the stack doesn't compile.

Part 4/9 of the split of #76.

## Why is this change being made?

- [ ] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

`xcodebuild -scheme KetchSDK -destination 'generic/platform=iOS Simulator' build` — succeeded.

## Related issues

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Refs #76 — layer 4 of 9 in the split of #76.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.