### PR TITLE
feat: add instance headless surface, config caching, and data-center routing

### DIFF
--- a/Sources/KetchSDK/Core/Ketch.swift
+++ b/Sources/KetchSDK/Core/Ketch.swift
@@ -31,8 +31,20 @@ public final class Ketch: ObservableObject {
     let propertyCode: String
     let environmentCode: String
     let identities: [Identity]
+    public let dataCenter: KetchDataCenter
+    private let apiRequest: KetchApiRequest
+    private let userDefaults: UserDefaults
     private let nativeStorage: NativeStorage
     private var plugins = Set<PolicyPlugin>()
+
+    // Headless getFullConfiguration() cache — avoids re-fetching when the config URL path is unchanged
+    private var cachedConfig: KetchSDK.Configuration?
+    private var cachedConfigKey: String?
+
+    // Headless getLocation() cache — GET /ip takes no path params, so it never needs invalidation
+    private var cachedLocation: KetchSDK.LocationResponse?
+
+    private let cacheLock = NSLock()
 
     private var configurationSubject = CurrentValueSubject<KetchSDK.Configuration?, KetchSDK.KetchError>(nil)
     private var localizedStringsSubject = CurrentValueSubject<KetchSDK.LocalizedStrings?, KetchSDK.KetchError>(nil)
@@ -51,12 +63,17 @@ public final class Ketch: ObservableObject {
         propertyCode: String,
         environmentCode: String,
         identities: [Identity],
-        userDefaults: UserDefaults = .standard
+        dataCenter: KetchDataCenter = .us,
+        userDefaults: UserDefaults = .standard,
+        apiClient: ApiClient = DefaultApiClient()
     ) {
         self.organizationCode = organizationCode
         self.propertyCode = propertyCode
         self.environmentCode = environmentCode
         self.identities = identities
+        self.dataCenter = dataCenter
+        self.apiRequest = KetchApiRequest(dataCenter: dataCenter, apiClient: apiClient)
+        self.userDefaults = userDefaults
         self.nativeStorage = NativeStorage(userDefaults: userDefaults)
 
         configurationSubject
@@ -99,7 +116,7 @@ public final class Ketch: ObservableObject {
     }
 
     public func loadConfiguration() {
-        KetchApiRequest()
+        apiRequest
             .fetchConfig(organization: organizationCode, property: propertyCode)
             .sink { result in
                 if case .failure(let error) = result {
@@ -109,7 +126,7 @@ public final class Ketch: ObservableObject {
                 self.configurationSubject.send(configuration)
             }
             .store(in: &subscriptions)
-        KetchApiRequest()
+        apiRequest
             .fetchLocalizedStrings()
             .sink { result in
                 if case .failure(let error) = result {
@@ -124,7 +141,7 @@ public final class Ketch: ObservableObject {
     public func loadConfiguration(
         jurisdiction: String
     ) {
-        KetchApiRequest()
+        apiRequest
             .fetchConfig(
                 organization: organizationCode,
                 property: propertyCode,
@@ -141,7 +158,7 @@ public final class Ketch: ObservableObject {
                 self.configurationSubject.send(configuration)
             }
             .store(in: &subscriptions)
-        KetchApiRequest()
+        apiRequest
             .fetchLocalizedStrings(languageCode:String(Locale.preferredLanguages[0].prefix(2)))
             .sink { result in
                 if case .failure(let error) = result {
@@ -164,7 +181,7 @@ public final class Ketch: ObservableObject {
             uniqueKeysWithValues: identities.map { ($0.key, $0.value) }
         )
 
-        return KetchApiRequest()
+        return apiRequest
             .invokeRights(
                 organization: organizationCode,
                 config: .init(
@@ -224,21 +241,22 @@ public final class Ketch: ObservableObject {
                 })
         else { return }
 
-        let identities = [String: String](
-            uniqueKeysWithValues: identities.map { ($0.key, $0.value) }
-        )
-
-        KetchApiRequest()
-            .getConsent(
-                config: .init(
-                    organizationCode: organizationCode,
-                    propertyCode: propertyCode,
-                    environmentCode: environmentCode,
-                    jurisdictionCode: jurisdictionCode,
-                    identities: identities,
-                    purposes: purposes
-                )
+        loadConsent(
+            consentConfig: .init(
+                organizationCode: organizationCode,
+                propertyCode: propertyCode,
+                environmentCode: environmentCode,
+                jurisdictionCode: jurisdictionCode,
+                identities: identityMap(),
+                purposes: purposes
             )
+        )
+    }
+
+    /// Fetches consent from the CDN without requiring WebView-loaded configuration.
+    public func loadConsent(consentConfig: KetchSDK.ConsentConfig) {
+        apiRequest
+            .getConsent(config: consentConfig)
             .sink { result in
                 if case .failure(let error) = result {
                     self.consentSubject.send(completion: .failure(error))
@@ -249,6 +267,10 @@ public final class Ketch: ObservableObject {
             .store(in: &subscriptions)
     }
 
+    private func identityMap() -> [String: String] {
+        [String: String](uniqueKeysWithValues: identities.map { ($0.key, $0.value) })
+    }
+
     public func updateConsent(
         purposes: [String: KetchSDK.ConsentUpdate.PurposeAllowedLegalBasis]?,
         vendors: [String]?,
@@ -256,17 +278,13 @@ public final class Ketch: ObservableObject {
     ) {
         guard let jurisdictionCode = configurationSubject.value?.jurisdiction?.code else { return }
 
-        let identities = [String: String](
-            uniqueKeysWithValues: identities.map { ($0.key, $0.value) }
-        )
-        
-        return KetchApiRequest()
-            .updateConsent(
+        return apiRequest
+            .setConsent(
                 update: .init(
                     organizationCode: organizationCode,
                     propertyCode: propertyCode,
                     environmentCode: environmentCode,
-                    identities: identities,
+                    identities: identityMap(),
                     jurisdictionCode: jurisdictionCode,
                     migrationOption: .migrateDefault,
                     purposes: purposes ?? [:],
@@ -278,19 +296,171 @@ public final class Ketch: ObservableObject {
                 if case .failure(let error) = result {
                     print(error)
                 }
-            } receiveValue: {
-                let purposesUpdate = purposes?.reduce(into: [String: Bool](), { result, purpose in
-                    result[purpose.key] = purpose.value.allowed
-                })
-                let consentUpdate = KetchSDK.ConsentStatus(
-                    purposes: purposesUpdate ?? [:],
-                    vendors: vendors,
-                    protocols: protocols
-                )
-
-                self.consentSubject.send(consentUpdate)
+            } receiveValue: { consentStatus in
+                self.consentSubject.send(consentStatus)
             }
             .store(in: &subscriptions)
+    }
+}
+
+// MARK: - Headless API (web/v3, pre-WebView)
+extension Ketch {
+    /// GeoIP location (`GET /ip`). Cached on this instance — `/ip` takes no path params, so the
+    /// cache never invalidates.
+    private func getLocation(
+        completion: @escaping (Result<KetchSDK.LocationResponse, KetchSDK.KetchError>) -> Void
+    ) {
+        cacheLock.lock()
+        if let cachedLocation {
+            cacheLock.unlock()
+            completion(.success(cachedLocation))
+            return
+        }
+        cacheLock.unlock()
+
+        apiRequest.getLocation()
+            .sink { if case .failure(let error) = $0 { completion(.failure(error)) } }
+            receiveValue: { location in
+                self.cacheLock.lock()
+                self.cachedLocation = location
+                self.cacheLock.unlock()
+                completion(.success(location))
+            }
+            .store(in: &subscriptions)
+    }
+
+    /// Combined ISO region code (e.g. "US-CA") from GeoIP. Backed by the same cache as [getLocation].
+    public func getRegion(
+        completion: @escaping (Result<String?, KetchSDK.KetchError>) -> Void
+    ) {
+        getLocation { result in
+            completion(result.map { $0.location?.toRegionCode() })
+        }
+    }
+
+    public func getBootstrapConfiguration(
+        completion: @escaping (Result<KetchSDK.Configuration, KetchSDK.KetchError>) -> Void
+    ) {
+        apiRequest.getBootstrapConfiguration(organization: organizationCode, property: propertyCode)
+            .sink { if case .failure(let error) = $0 { completion(.failure(error)) } }
+            receiveValue: { completion(.success($0)) }
+            .store(in: &subscriptions)
+    }
+
+    /// Full config with optional env/jurisdiction/language and hash query param.
+    ///
+    /// Cached on this instance, keyed on the request's URL-path-affecting fields. A cache hit
+    /// skips the network call entirely.
+    public func getFullConfiguration(
+        request: KetchSDK.FullConfigurationRequest,
+        completion: @escaping (Result<KetchSDK.Configuration, KetchSDK.KetchError>) -> Void
+    ) {
+        let key = Self.buildConfigCacheKey(for: request)
+        cacheLock.lock()
+        if cachedConfigKey == key, let cachedConfig {
+            cacheLock.unlock()
+            completion(.success(cachedConfig))
+            return
+        }
+        cacheLock.unlock()
+
+        apiRequest.getFullConfiguration(request: request)
+            .sink { if case .failure(let error) = $0 { completion(.failure(error)) } }
+            receiveValue: { configuration in
+                self.cacheLock.lock()
+                self.cachedConfig = configuration
+                self.cachedConfigKey = key
+                self.cacheLock.unlock()
+                completion(.success(configuration))
+            }
+            .store(in: &subscriptions)
+    }
+
+    /// Resolved jurisdiction code for this instance's current org/property/environment, e.g. from
+    /// a `jurisdiction` `ExperienceOption`. Backed by the same cache as [getFullConfiguration].
+    public func getJurisdiction(
+        completion: @escaping (Result<String?, KetchSDK.KetchError>) -> Void
+    ) {
+        getFullConfiguration(request: buildJurisdictionConfigRequest()) { result in
+            completion(result.map { $0.jurisdictionCode() })
+        }
+    }
+
+    private func buildJurisdictionConfigRequest() -> KetchSDK.FullConfigurationRequest {
+        .init(
+            organizationCode: organizationCode,
+            propertyCode: propertyCode,
+            environmentCode: environmentCode
+        )
+    }
+
+    // Cache key for getFullConfiguration() — mirrors HeadlessApiClient's path- and query-building
+    // exactly via configPathSegment()/configQueryItems(), so requests that hit the same URL
+    // always share a key and requests that hit different URLs never collide.
+    private static func buildConfigCacheKey(for request: KetchSDK.FullConfigurationRequest) -> String {
+        let segment = request.configPathSegment()
+        let query = request.configQueryItems().map { "\($0.name)=\($0.value ?? "")" }
+        return ([
+            request.organizationCode,
+            request.propertyCode,
+            segment?.env ?? "",
+            segment?.jurisdiction ?? "",
+            segment?.language ?? ""
+        ] + query).joined(separator: "|")
+    }
+
+    public func getConsent(
+        consentConfig: KetchSDK.ConsentConfig,
+        completion: @escaping (Result<KetchSDK.ConsentStatus, KetchSDK.KetchError>) -> Void
+    ) {
+        apiRequest.getConsent(config: consentConfig)
+            .sink { if case .failure(let error) = $0 { completion(.failure(error)) } }
+            receiveValue: { completion(.success($0)) }
+            .store(in: &subscriptions)
+    }
+
+    public func setConsent(
+        consentUpdate: KetchSDK.ConsentUpdate,
+        completion: @escaping (Result<KetchSDK.ConsentStatus, KetchSDK.KetchError>) -> Void
+    ) {
+        apiRequest.setConsent(update: consentUpdate)
+            .sink { if case .failure(let error) = $0 { completion(.failure(error)) } }
+            receiveValue: { completion(.success($0)) }
+            .store(in: &subscriptions)
+    }
+
+    public func invokeRight(
+        request: KetchSDK.InvokeRightRequest,
+        completion: @escaping (Result<Void, KetchSDK.KetchError>) -> Void
+    ) {
+        apiRequest.invokeRight(request: request)
+            .sink { if case .failure(let error) = $0 { completion(.failure(error)) } }
+            receiveValue: { completion(.success(())) }
+            .store(in: &subscriptions)
+    }
+
+    public func getSubscriptions(
+        request: KetchSDK.SubscriptionsRequest,
+        completion: @escaping (Result<KetchSDK.SubscriptionsResponse, KetchSDK.KetchError>) -> Void
+    ) {
+        apiRequest.getSubscriptions(request: request)
+            .sink { if case .failure(let error) = $0 { completion(.failure(error)) } }
+            receiveValue: { completion(.success($0)) }
+            .store(in: &subscriptions)
+    }
+
+    public func setSubscriptions(
+        request: KetchSDK.SubscriptionsRequest,
+        completion: @escaping (Result<Void, KetchSDK.KetchError>) -> Void
+    ) {
+        apiRequest.setSubscriptions(request: request)
+            .sink { if case .failure(let error) = $0 { completion(.failure(error)) } }
+            receiveValue: { completion(.success(())) }
+            .store(in: &subscriptions)
+    }
+
+    public func getPreferenceQRUrl(request: KetchSDK.PreferenceQRRequest) -> URL? {
+        apiRequest.getPreferenceQRUrl(request: request)
     }
 }
 
@@ -314,8 +484,8 @@ extension Ketch {
         property: String,
         completion: @escaping (Result<KetchSDK.Configuration, KetchSDK.KetchError>
     ) -> Void) {
-        KetchApiRequest()
-            .fetchConfig(organization: organization, property: organization)
+        apiRequest
+            .fetchConfig(organization: organization, property: property)
             .sink { result in
                 if case .failure(let error) = result {
                     completion(.failure(error))
@@ -330,32 +500,19 @@ extension Ketch {
         consentConfig: KetchSDK.ConsentConfig,
         completion: @escaping (Result<KetchSDK.ConsentStatus, KetchSDK.KetchError>) -> Void
     ) {
-        KetchApiRequest()
-            .getConsent(config: consentConfig)
-            .sink { result in
-                if case .failure(let error) = result {
-                    completion(.failure(error))
-                }
-            } receiveValue: { consentStatus in
-                completion(.success(consentStatus))
-            }
-            .store(in: &subscriptions)
+        getConsent(consentConfig: consentConfig, completion: completion)
     }
 
     public func fetchSetConsent(
         consentUpdate: KetchSDK.ConsentUpdate,
         completion: @escaping (Result<Void, KetchSDK.KetchError>) -> Void
     ) {
-        KetchApiRequest()
-            .updateConsent(update: consentUpdate)
-            .sink { result in
-                if case .failure(let error) = result {
-                    completion(.failure(error))
-                }
-            } receiveValue: {
-                completion(.success(()))
+        setConsent(consentUpdate: consentUpdate) { result in
+            switch result {
+            case .success: completion(.success(()))
+            case .failure(let error): completion(.failure(error))
             }
-            .store(in: &subscriptions)
+        }
     }
 
     public func fetchInvokeRights(
@@ -363,7 +520,7 @@ extension Ketch {
         config: KetchSDK.InvokeRightConfig,
         completion: @escaping (Result<Void, KetchSDK.KetchError>) -> Void
     ) {
-        KetchApiRequest()
+        apiRequest
             .invokeRights(
                 organization: organization,
                 config: config

--- a/Sources/KetchSDK/Core/Ketch.swift
+++ b/Sources/KetchSDK/Core/Ketch.swift
@@ -44,6 +44,12 @@ public final class Ketch: ObservableObject {
     // Headless getLocation() cache — GET /ip takes no path params, so it never needs invalidation
     private var cachedLocation: KetchSDK.LocationResponse?
 
+    // Local overrides for getRegion()/getJurisdiction(), set via setRegion()/setJurisdiction().
+    // Take precedence over the server-resolved values; also fed into buildJurisdictionConfigRequest()
+    // so a jurisdiction override is reflected in the request path, not just the getter's return value.
+    private var region: String?
+    private var jurisdiction: String?
+
     private let cacheLock = NSLock()
 
     private var configurationSubject = CurrentValueSubject<KetchSDK.Configuration?, KetchSDK.KetchError>(nil)
@@ -329,13 +335,27 @@ extension Ketch {
             .store(in: &subscriptions)
     }
 
-    /// Combined ISO region code (e.g. "US-CA") from GeoIP. Backed by the same cache as [getLocation].
+    /// Combined ISO region code (e.g. "US-CA"). Returns the value from `setRegion` if one is set
+    /// on this instance; otherwise falls back to GeoIP (`GET /ip`), cached on this instance via
+    /// [getLocation].
     public func getRegion(
         completion: @escaping (Result<String?, KetchSDK.KetchError>) -> Void
     ) {
+        if let region {
+            completion(.success(region))
+            return
+        }
         getLocation { result in
             completion(result.map { $0.location?.toRegionCode() })
         }
+    }
+
+    /// Overrides the value returned by `getRegion()`, bypassing the GeoIP round-trip. Also feeds
+    /// `getJurisdiction()`'s config request, so pass `nil` to clear the override and resume
+    /// resolving both from the server.
+    public func setRegion(_ region: String?) {
+        self.region = region
+        clearConfigCache()
     }
 
     public func getBootstrapConfiguration(
@@ -376,22 +396,44 @@ extension Ketch {
             .store(in: &subscriptions)
     }
 
-    /// Resolved jurisdiction code for this instance's current org/property/environment, e.g. from
-    /// a `jurisdiction` `ExperienceOption`. Backed by the same cache as [getFullConfiguration].
+    /// Resolved jurisdiction code for this instance's current org/property/environment. Returns
+    /// the value from `setJurisdiction` if one is set on this instance; otherwise falls back to
+    /// the server-resolved code from [getFullConfiguration], which the same cache backs.
     public func getJurisdiction(
         completion: @escaping (Result<String?, KetchSDK.KetchError>) -> Void
     ) {
+        if let jurisdiction {
+            completion(.success(jurisdiction))
+            return
+        }
         getFullConfiguration(request: buildJurisdictionConfigRequest()) { result in
             completion(result.map { $0.jurisdictionCode() })
         }
+    }
+
+    /// Overrides the value returned by `getJurisdiction()`, bypassing the server round-trip and
+    /// invalidating the [getFullConfiguration] cache, since jurisdiction affects the config URL
+    /// path. Pass `nil` to clear the override and resume resolving from the server.
+    public func setJurisdiction(_ jurisdiction: String?) {
+        self.jurisdiction = jurisdiction
+        clearConfigCache()
     }
 
     private func buildJurisdictionConfigRequest() -> KetchSDK.FullConfigurationRequest {
         .init(
             organizationCode: organizationCode,
             propertyCode: propertyCode,
-            environmentCode: environmentCode
+            environmentCode: environmentCode,
+            jurisdictionCode: jurisdiction,
+            regionCode: region
         )
+    }
+
+    private func clearConfigCache() {
+        cacheLock.lock()
+        cachedConfig = nil
+        cachedConfigKey = nil
+        cacheLock.unlock()
     }
 
     // Cache key for getFullConfiguration() — mirrors HeadlessApiClient's path- and query-building

--- a/Sources/KetchSDK/UI/KetchUI.swift
+++ b/Sources/KetchSDK/UI/KetchUI.swift
@@ -68,7 +68,16 @@ public final class KetchUI: ObservableObject {
     
     private func preloadWebExperience() {
         preloadedPresentationItem = webExperience(onEvent: handle)
-        preloadedPresentationItem?.reload(options: options)
+        preloadedPresentationItem?.reload(options: experienceOptionsWithDataCenter(options))
+    }
+
+    private func experienceOptionsWithDataCenter(_ options: [ExperienceOption]) -> [ExperienceOption] {
+        guard !options.contains(where: { if case .ketchURL = $0 { return true }; return false }) else {
+            return options
+        }
+        var result = options
+        result.append(.ketchURL(ketch.dataCenter.baseURL.absoluteString))
+        return result
     }
     
     private func handle(webPresentationEvent: WebPresentationItem.Event) {
@@ -173,7 +182,7 @@ extension KetchUI {
             newOptions.append(option)
         }
         
-        preloadedPresentationItem?.reload(options: newOptions)
+        preloadedPresentationItem?.reload(options: experienceOptionsWithDataCenter(newOptions))
     }
     
     public func showExperience() {

--- a/Tests/KetchSDKTests/KetchHeadlessCachingTests.swift
+++ b/Tests/KetchSDKTests/KetchHeadlessCachingTests.swift
@@ -1,0 +1,198 @@
+import Combine
+import XCTest
+@testable import KetchSDK
+
+final class KetchHeadlessCachingTests: XCTestCase {
+    func testGetRegion_cachesLocationAcrossCalls() {
+        let apiClient = CountingApiClient { _ in
+            Just(Data("""
+            {"location":{"countryCode":"US","regionCode":"CA"}}
+            """.utf8))
+                .setFailureType(to: ApiClientError.self)
+                .eraseToAnyPublisher()
+        }
+        let ketch = Ketch(
+            organizationCode: "acme",
+            propertyCode: "prop",
+            environmentCode: "production",
+            identities: [],
+            apiClient: apiClient
+        )
+
+        let first = expectation(description: "first getRegion")
+        ketch.getRegion { result in
+            XCTAssertEqual(try? result.get(), "US-CA")
+            first.fulfill()
+        }
+        wait(for: [first], timeout: 5)
+
+        let second = expectation(description: "second getRegion")
+        ketch.getRegion { result in
+            XCTAssertEqual(try? result.get(), "US-CA")
+            second.fulfill()
+        }
+        wait(for: [second], timeout: 5)
+
+        XCTAssertEqual(apiClient.callCount, 1, "getRegion should hit the network only once; repeat calls should be served from cache")
+    }
+
+    func testGetFullConfiguration_sameRequest_servedFromCache() {
+        let apiClient = CountingApiClient { _ in
+            Just(Data("{}".utf8)).setFailureType(to: ApiClientError.self).eraseToAnyPublisher()
+        }
+        let ketch = Ketch(
+            organizationCode: "acme",
+            propertyCode: "prop",
+            environmentCode: "production",
+            identities: [],
+            apiClient: apiClient
+        )
+        let request = KetchSDK.FullConfigurationRequest(
+            organizationCode: "acme",
+            propertyCode: "prop",
+            environmentCode: "production",
+            jurisdictionCode: "us-ca",
+            languageCode: "en-US"
+        )
+
+        let first = expectation(description: "first getFullConfiguration")
+        ketch.getFullConfiguration(request: request) { _ in first.fulfill() }
+        wait(for: [first], timeout: 5)
+
+        let second = expectation(description: "second getFullConfiguration")
+        ketch.getFullConfiguration(request: request) { _ in second.fulfill() }
+        wait(for: [second], timeout: 5)
+
+        XCTAssertEqual(apiClient.callCount, 1, "Identical requests should be served from the config cache")
+    }
+
+    func testGetFullConfiguration_differentRequest_missesCache() {
+        let apiClient = CountingApiClient { _ in
+            Just(Data("{}".utf8)).setFailureType(to: ApiClientError.self).eraseToAnyPublisher()
+        }
+        let ketch = Ketch(
+            organizationCode: "acme",
+            propertyCode: "prop",
+            environmentCode: "production",
+            identities: [],
+            apiClient: apiClient
+        )
+
+        let first = expectation(description: "first getFullConfiguration")
+        ketch.getFullConfiguration(
+            request: .init(
+                organizationCode: "acme",
+                propertyCode: "prop",
+                environmentCode: "production",
+                jurisdictionCode: "us-ca",
+                languageCode: "en-US"
+            )
+        ) { _ in first.fulfill() }
+        wait(for: [first], timeout: 5)
+
+        let second = expectation(description: "second getFullConfiguration, different jurisdiction")
+        ketch.getFullConfiguration(
+            request: .init(
+                organizationCode: "acme",
+                propertyCode: "prop",
+                environmentCode: "production",
+                jurisdictionCode: "eu-fr",
+                languageCode: "en-US"
+            )
+        ) { _ in second.fulfill() }
+        wait(for: [second], timeout: 5)
+
+        XCTAssertEqual(apiClient.callCount, 2, "Requests that hit different config URLs must not share a cache entry")
+    }
+
+    func testGetFullConfiguration_differentRegionOnShortPath_missesCache() {
+        let apiClient = CountingApiClient { _ in
+            Just(Data("{}".utf8)).setFailureType(to: ApiClientError.self).eraseToAnyPublisher()
+        }
+        let ketch = Ketch(
+            organizationCode: "acme",
+            propertyCode: "prop",
+            environmentCode: "production",
+            identities: [],
+            apiClient: apiClient
+        )
+
+        let first = expectation(description: "first getFullConfiguration")
+        ketch.getFullConfiguration(
+            request: .init(organizationCode: "acme", propertyCode: "prop", regionCode: "US-CA")
+        ) { _ in first.fulfill() }
+        wait(for: [first], timeout: 5)
+
+        let second = expectation(description: "second getFullConfiguration, different region")
+        ketch.getFullConfiguration(
+            request: .init(organizationCode: "acme", propertyCode: "prop", regionCode: "US-NY")
+        ) { _ in second.fulfill() }
+        wait(for: [second], timeout: 5)
+
+        XCTAssertEqual(apiClient.callCount, 2, "A regionCode-only difference on the short path must not share a cache entry")
+    }
+
+    func testGetJurisdiction_returnsCodeFromConfig() {
+        let apiClient = CountingApiClient { _ in
+            Just(Data("""
+            {"jurisdiction":{"code":"us-ca","defaultJurisdictionCode":"us"}}
+            """.utf8))
+                .setFailureType(to: ApiClientError.self)
+                .eraseToAnyPublisher()
+        }
+        let ketch = Ketch(
+            organizationCode: "acme",
+            propertyCode: "prop",
+            environmentCode: "production",
+            identities: [],
+            apiClient: apiClient
+        )
+
+        let expectation = expectation(description: "getJurisdiction")
+        ketch.getJurisdiction { result in
+            XCTAssertEqual(try? result.get(), "us-ca")
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 5)
+    }
+
+    func testGetJurisdiction_fallsBackToDefaultJurisdictionCode() {
+        let apiClient = CountingApiClient { _ in
+            Just(Data("""
+            {"jurisdiction":{"defaultJurisdictionCode":"us"}}
+            """.utf8))
+                .setFailureType(to: ApiClientError.self)
+                .eraseToAnyPublisher()
+        }
+        let ketch = Ketch(
+            organizationCode: "acme",
+            propertyCode: "prop",
+            environmentCode: "production",
+            identities: [],
+            apiClient: apiClient
+        )
+
+        let expectation = expectation(description: "getJurisdiction fallback")
+        ketch.getJurisdiction { result in
+            XCTAssertEqual(try? result.get(), "us")
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 5)
+    }
+}
+
+// MARK: - Test doubles
+
+private final class CountingApiClient: ApiClient {
+    private(set) var callCount = 0
+    private let handler: (ApiRequest) -> AnyPublisher<Data, ApiClientError>
+
+    init(handler: @escaping (ApiRequest) -> AnyPublisher<Data, ApiClientError>) {
+        self.handler = handler
+    }
+
+    func execute(request: ApiRequest) -> AnyPublisher<Data, ApiClientError> {
+        callCount += 1
+        return handler(request)
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Code generated by shipbuilder init 1.21.3. DO NOT EDIT. -->

## Description of this change

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

Adds the instance-level headless surface on `Ketch`: `getRegion`, `getJurisdiction`, `getBootstrapConfiguration`, `getFullConfiguration`, `getConsent`, `setConsent`, `invokeRight`, `getSubscriptions`, `setSubscriptions`, `getPreferenceQRUrl`, config caching (`cachedConfig`/`cachedConfigKey`/`buildConfigCacheKey`), and data-center routing. Fixes the remaining two callers of the old `KetchApiRequest.updateConsent` (renamed to `setConsent` in #81) that lived in `Ketch.swift`. Includes a real bug fix: `property: organization` → `property: property` in the invoke-rights request. Test coverage: `KetchHeadlessCachingTests.swift`.

Pulled forward from where the original PR's diff would place this, for two reasons: (1) it carries the second and third fixes for the `updateConsent`→`setConsent` rename from #81, and (2) the test layer (#86) exercises `Ketch.getRegion`/`getJurisdiction` directly and won't compile without this landing first.

Also carries the fix for a top-level comment on #76 noting `dataCenter` wasn't passed to the WebView as `ketch_mobilesdk_url` — already fixed on this branch (`experienceOptionsWithDataCenter()`), riding along here since it touches the same hunks.

Part 5/9 of the split of #76.

Also fixes `getRegion()`/`getJurisdiction()`: they ignored any locally-set override. Adds `setRegion(_:)`/`setJurisdiction(_:)`; both getters now check the override before hitting the network.

## Why is this change being made?

- [ ] Chore (non-functional changes)
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

`xcodebuild -scheme KetchSDK -destination 'generic/platform=iOS Simulator' build` — succeeded.

## Related issues

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Refs #76 — layer 5 of 9 in the split of #76.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.