### PR TITLE
fix: present experience for every show path and dispatch PolicyPlugin lifecycle events

### DIFF
--- a/Sources/KetchSDK/Core/Ketch.swift
+++ b/Sources/KetchSDK/Core/Ketch.swift
@@ -613,6 +613,22 @@ extension Ketch {
     }
 }
 
+// MARK: - Internal interface for plugin lifecycle events
+extension Ketch {
+    func notifyWillShowExperience() {
+        plugins.forEach { plugin in
+            plugin.willShowExperience()
+        }
+    }
+
+    func notifyExperienceHidden(status: KetchSDK.HideExperienceStatus) {
+        let reason = ExperienceHiddenReason(status: status)
+        plugins.forEach { plugin in
+            plugin.experienceHidden(reason: reason)
+        }
+    }
+}
+
 private let CONSENT_VERSION = "consent_version"
 private let PREFERENCE_VERSION = "preference_version"
 

--- a/Sources/KetchSDK/Core/PolicyProtocol.swift
+++ b/Sources/KetchSDK/Core/PolicyProtocol.swift
@@ -42,6 +42,21 @@ public enum ExperienceHiddenReason: String {
   case invokeRight
   case close
   case willNotShow
+  case closeWithoutSettingConsent
+  case setSubscriptions
+  case none
+
+  init(status: KetchSDK.HideExperienceStatus) {
+    switch status {
+    case .SetConsent: self = .setConsent
+    case .InvokeRight: self = .invokeRight
+    case .Close: self = .close
+    case .WillNotShow: self = .willNotShow
+    case .CloseWithoutSettingConsent: self = .closeWithoutSettingConsent
+    case .SetSubscriptions: self = .setSubscriptions
+    case .None: self = .none
+    }
+  }
 }
 
 public enum PolicyPluginError: Error {

--- a/Sources/KetchSDK/UI/KetchUI.swift
+++ b/Sources/KetchSDK/UI/KetchUI.swift
@@ -86,15 +86,13 @@ public final class KetchUI: ObservableObject {
             didCloseExperience(status: status)
             
         case .show(let content):
-            if isConfigLoaded {
-                self.showExperience()
-                eventListener?.onShow()
-            } else {
-                experienceToShow = content
-            }
-            
+            presentExperience(content)
+
         case .willShowExperience(let type):
             eventListener?.onWillShowExperience(type: type)
+            ketch.notifyWillShowExperience()
+            // The only show signal guaranteed to fire for every experience path.
+            presentExperience(type == .ConsentExperience ? .consent : .preference)
             
         case .hasShownExperience:
             eventListener?.onHasShownExperience()
@@ -148,6 +146,16 @@ public final class KetchUI: ObservableObject {
     private func didCloseExperience(status: KetchSDK.HideExperienceStatus) {
         webPresentationItem = nil
         eventListener?.onDismiss(status: status)
+        ketch.notifyExperienceHidden(status: status)
+    }
+
+    private func presentExperience(_ content: WebPresentationItem.Event.Content) {
+        if isConfigLoaded {
+            showExperience()
+            eventListener?.onShow()
+        } else {
+            experienceToShow = content
+        }
     }
     
     private var display: KetchSDK.Configuration.Experience.ContentDisplay {

--- a/Sources/KetchSDK/UI/KetchUI.swift
+++ b/Sources/KetchSDK/UI/KetchUI.swift
@@ -151,6 +151,9 @@ public final class KetchUI: ObservableObject {
 
     private func presentExperience(_ content: WebPresentationItem.Event.Content) {
         if isConfigLoaded {
+            // .show and .willShowExperience both fire for the same experience on the warm path;
+            // only the first to arrive should actually dispatch showExperience()/onShow().
+            guard webPresentationItem == nil else { return }
             showExperience()
             eventListener?.onShow()
         } else {

--- a/Tests/KetchSDKTests/PolicyPluginDispatchTests.swift
+++ b/Tests/KetchSDKTests/PolicyPluginDispatchTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+@testable import KetchSDK
+
+final class PolicyPluginDispatchTests: XCTestCase {
+
+    func testWillShowExperienceReachesRegisteredPlugin() {
+        let ketch = Ketch(organizationCode: "acme", propertyCode: "prop", environmentCode: "production", identities: [])
+        let plugin = SpyPolicyPlugin()
+        ketch.add(plugin: plugin)
+
+        ketch.notifyWillShowExperience()
+
+        XCTAssertEqual(plugin.willShowExperienceCount, 1)
+    }
+
+    func testExperienceHiddenReachesRegisteredPluginWithMappedReason() {
+        let ketch = Ketch(organizationCode: "acme", propertyCode: "prop", environmentCode: "production", identities: [])
+        let plugin = SpyPolicyPlugin()
+        ketch.add(plugin: plugin)
+
+        ketch.notifyExperienceHidden(status: .Close)
+
+        XCTAssertEqual(plugin.hiddenReasons, [.close])
+    }
+
+    func testExperienceHiddenReasonMapsEveryHideExperienceStatus() {
+        let ketch = Ketch(organizationCode: "acme", propertyCode: "prop", environmentCode: "production", identities: [])
+        let plugin = SpyPolicyPlugin()
+        ketch.add(plugin: plugin)
+
+        let statuses: [KetchSDK.HideExperienceStatus] = [
+            .SetConsent, .InvokeRight, .Close, .WillNotShow,
+            .CloseWithoutSettingConsent, .SetSubscriptions, .None
+        ]
+        statuses.forEach { ketch.notifyExperienceHidden(status: $0) }
+
+        XCTAssertEqual(plugin.hiddenReasons, [
+            .setConsent, .invokeRight, .close, .willNotShow,
+            .closeWithoutSettingConsent, .setSubscriptions, .none
+        ])
+    }
+}
+
+// MARK: - Test doubles
+
+private final class SpyPolicyPlugin: PolicyPlugin {
+    override var protocolID: String { "spy-policy-plugin" }
+    override var isApplied: Bool { true }
+
+    private(set) var willShowExperienceCount = 0
+    private(set) var hiddenReasons: [ExperienceHiddenReason] = []
+
+    override func willShowExperience() {
+        willShowExperienceCount += 1
+    }
+
+    override func experienceHidden(reason: ExperienceHiddenReason) {
+        hiddenReasons.append(reason)
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Code generated by shipbuilder init 1.21.3. DO NOT EDIT. -->

## Description of this change

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

Presents the experience for every show path and dispatches `PolicyPlugin` lifecycle events (`notifyWillShowExperience`, `notifyExperienceHidden(status:)`). Adds `PolicyPluginDispatchTests.swift`. The presentation fix and the PolicyPlugin dispatch share two `KetchUI.swift` hunks that can't be separated — each hunk touches both concerns.

Part 6/9 of the split of #76.

Also fixes a duplicate `onShow()`: both `.show` and `.willShowExperience` dispatched it on the warm path. Now only the first arrival does.

## Why is this change being made?

- [ ] Chore (non-functional changes)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

`xcodebuild -scheme KetchSDK -destination 'generic/platform=iOS Simulator' build` — succeeded.

## Related issues

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Refs #76 — layer 6 of 9 in the split of #76.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.