### PR TITLE
feat: add onFunction rule trigger support

### DIFF
--- a/Sources/KetchSDK/UI/KetchUI.swift
+++ b/Sources/KetchSDK/UI/KetchUI.swift
@@ -33,6 +33,15 @@ public final class KetchUI: ObservableObject {
     private var experienceToShow: KetchUI.WebPresentationItem.Event.Content?
     private var preloadedPresentationItem: WebPresentationItem?
 
+    // Deferred trigger() call, fired once a cold-booted WebView's tag finishes loading
+    private var pendingTrigger: PendingTrigger?
+
+    private struct PendingTrigger {
+        let triggerName: TriggerName
+        let functionName: String
+        let optionsJson: String
+    }
+
     /// Instantiation of UI dialogs
     /// - Parameter ketch: Instance of Ketch that will provide request and storage services,
     /// - Parameter options: default options
@@ -102,9 +111,18 @@ public final class KetchUI: ObservableObject {
             
         case .configurationLoaded(let configuration):
             self.ketch.configuration = configuration
-            
+
             isConfigLoaded = true
-            
+
+            if let pending = pendingTrigger {
+                pendingTrigger = nil
+                preloadedPresentationItem?.trigger(
+                    triggerName: pending.triggerName.rawValue,
+                    functionName: pending.functionName,
+                    optionsJson: pending.optionsJson
+                )
+            }
+
             if experienceToShow != nil {
                 showExperience()
                 self.experienceToShow = nil
@@ -212,6 +230,55 @@ extension KetchUI {
     
     public func closeExperience() {
         webPresentationItem = nil
+    }
+
+    /// Fires a custom-function (`onFunction`) rule trigger. If a matching backend rule shows an
+    /// experience, it is displayed automatically.
+    ///
+    /// - Parameters:
+    ///   - triggerName: the trigger name; `.custom` is the only supported value today
+    ///   - functionName: the custom function name configured on the backend rule
+    ///   - options: optional key/value trigger arguments
+    /// - Returns: `false` if `functionName` is invalid, or an experience is already showing.
+    @discardableResult
+    public func trigger(
+        triggerName: TriggerName,
+        functionName: String,
+        options: [String: Any] = [:]
+    ) -> Bool {
+        guard Self.isValidTriggerFunctionName(functionName) else {
+            KetchLogger.log.debug("[Ketch] trigger rejected: functionName must be non-blank and contain only letters, digits, '_', '-', or '.'")
+            return false
+        }
+        guard webPresentationItem == nil else {
+            KetchLogger.log.debug("Not triggering '\(functionName)' as an experience is already being shown")
+            return false
+        }
+
+        let optionsJson = Self.jsonString(from: options)
+
+        if isConfigLoaded {
+            pendingTrigger = nil
+            preloadedPresentationItem?.trigger(triggerName: triggerName.rawValue, functionName: functionName, optionsJson: optionsJson)
+        } else {
+            pendingTrigger = PendingTrigger(triggerName: triggerName, functionName: functionName, optionsJson: optionsJson)
+        }
+        return true
+    }
+
+    /// Mirrors ketch-tag's function-name validation: non-blank, and only letters, digits, '_', '-', or '.'.
+    static func isValidTriggerFunctionName(_ functionName: String) -> Bool {
+        !functionName.isEmpty
+            && functionName.range(of: "^[A-Za-z0-9_.-]+$", options: .regularExpression) != nil
+    }
+
+    private static func jsonString(from options: [String: Any]) -> String {
+        guard let data = try? JSONSerialization.data(withJSONObject: options),
+              let json = String(data: data, encoding: .utf8)
+        else {
+            return "{}"
+        }
+        return json
     }
 }
 

--- a/Sources/KetchSDK/UI/KetchUI.swift
+++ b/Sources/KetchSDK/UI/KetchUI.swift
@@ -29,14 +29,20 @@ public final class KetchUI: ObservableObject {
     private(set) public var ketch: Ketch
     private var subscriptions = Set<AnyCancellable>()
     private var options = [ExperienceOption]()
-    private var isConfigLoaded = false
+    // Whether the *currently loaded* page's tag has finished booting (emitted .configurationLoaded).
+    // Distinct from "an experience is pending" (experienceToShow) or "queued" (pendingTrigger) --
+    // those track what should happen once the tag boots, this tracks whether it has.
+    // internal, not private: exercised directly by TriggerValidationTests via @testable import,
+    // since there is no test seam for driving the WebPresentationItem bridge from outside.
+    var isTagBooted = false
     private var experienceToShow: KetchUI.WebPresentationItem.Event.Content?
     private var preloadedPresentationItem: WebPresentationItem?
 
-    // Deferred trigger() call, fired once a cold-booted WebView's tag finishes loading
-    private var pendingTrigger: PendingTrigger?
+    // Deferred trigger() call, fired once a cold-booted WebView's tag finishes loading.
+    // internal, not private: see isTagBooted's comment above.
+    var pendingTrigger: PendingTrigger?
 
-    private struct PendingTrigger {
+    struct PendingTrigger {
         let triggerName: TriggerName
         let functionName: String
         let optionsJson: String
@@ -76,8 +82,16 @@ public final class KetchUI: ObservableObject {
     }
     
     private func preloadWebExperience() {
+        resetBridgeState()
         preloadedPresentationItem = webExperience(onEvent: handle)
         preloadedPresentationItem?.reload(options: experienceOptionsWithDataCenter(options))
+    }
+
+    // Single choke point for "a new page is about to load". Resets the state that describes the
+    // *current* page, but deliberately leaves pendingTrigger alone -- a trigger() queued before a
+    // reload should still fire once the new page's tag boots, not be discarded by the reload.
+    private func resetBridgeState() {
+        isTagBooted = false
     }
 
     private func experienceOptionsWithDataCenter(_ options: [ExperienceOption]) -> [ExperienceOption] {
@@ -89,7 +103,8 @@ public final class KetchUI: ObservableObject {
         return result
     }
     
-    private func handle(webPresentationEvent: WebPresentationItem.Event) {
+    // internal, not private: see isTagBooted's comment above.
+    func handle(webPresentationEvent: WebPresentationItem.Event) {
         switch webPresentationEvent {
         case .onClose(let status):
             didCloseExperience(status: status)
@@ -112,7 +127,7 @@ public final class KetchUI: ObservableObject {
         case .configurationLoaded(let configuration):
             self.ketch.configuration = configuration
 
-            isConfigLoaded = true
+            isTagBooted = true
 
             if let pending = pendingTrigger {
                 pendingTrigger = nil
@@ -126,7 +141,6 @@ public final class KetchUI: ObservableObject {
             if experienceToShow != nil {
                 showExperience()
                 self.experienceToShow = nil
-                isConfigLoaded = false
                 eventListener?.onShow()
             }
 
@@ -168,7 +182,7 @@ public final class KetchUI: ObservableObject {
     }
 
     private func presentExperience(_ content: WebPresentationItem.Event.Content) {
-        if isConfigLoaded {
+        if isTagBooted {
             // .show and .willShowExperience both fire for the same experience on the warm path;
             // only the first to arrive should actually dispatch showExperience()/onShow().
             guard webPresentationItem == nil else { return }
@@ -198,9 +212,10 @@ public final class KetchUI: ObservableObject {
 // MARK: - Direct trigger of dialog item presentation
 extension KetchUI {
     public func reload(with options: [ExperienceOption] = []) {
+        resetBridgeState()
         preloadedPresentationItem?.webView?.configuration.userContentController.removeAllScriptMessageHandlers()
         preloadedPresentationItem = webExperience(onEvent: handle)
-        
+
         // merge options, override existing if needed
         var newOptions = self.options
         options.forEach { option in
@@ -257,7 +272,7 @@ extension KetchUI {
 
         let optionsJson = Self.jsonString(from: options)
 
-        if isConfigLoaded {
+        if isTagBooted {
             pendingTrigger = nil
             preloadedPresentationItem?.trigger(triggerName: triggerName.rawValue, functionName: functionName, optionsJson: optionsJson)
         } else {

--- a/Sources/KetchSDK/UI/PresentationItem/PresentationItem.swift
+++ b/Sources/KetchSDK/UI/PresentationItem/PresentationItem.swift
@@ -319,9 +319,14 @@ extension KetchUI.WebPresentationItem {
     public func showPreferences() {
         webView?.evaluateJavaScript("ketch('showPreferences')")
     }
-    
+
     public func showConsent() {
         webView?.evaluateJavaScript("ketch('showConsent')")
+    }
+
+    /// Fires a custom-function (`onFunction`) rule trigger on an already-booted page.
+    func trigger(triggerName: String, functionName: String, optionsJson: String) {
+        webView?.evaluateJavaScript("ketch('trigger', '\(triggerName)', '\(functionName)', \(optionsJson))")
     }
 }
 

--- a/Sources/KetchSDK/UI/TriggerName.swift
+++ b/Sources/KetchSDK/UI/TriggerName.swift
@@ -1,0 +1,10 @@
+//
+//  TriggerName.swift
+//  KetchSDK
+//
+
+/// The trigger name for `KetchUI.trigger` — mirrors ketch-tag's `ketch('trigger', <triggerName>, ...)`
+/// call shape. `.custom` is the only supported value today.
+public enum TriggerName: String {
+    case custom
+}

--- a/Tests/KetchSDKTests/TriggerValidationTests.swift
+++ b/Tests/KetchSDKTests/TriggerValidationTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import KetchSDK
+
+final class TriggerValidationTests: XCTestCase {
+    func testValidFunctionName_lettersDigitsUnderscoreDotDash() {
+        XCTAssertTrue(KetchUI.isValidTriggerFunctionName("myFunction_1.name-2"))
+    }
+
+    func testValidFunctionName_singleCharacter() {
+        XCTAssertTrue(KetchUI.isValidTriggerFunctionName("a"))
+    }
+
+    func testInvalidFunctionName_empty() {
+        XCTAssertFalse(KetchUI.isValidTriggerFunctionName(""))
+    }
+
+    func testInvalidFunctionName_blankWhitespace() {
+        XCTAssertFalse(KetchUI.isValidTriggerFunctionName(" "))
+    }
+
+    func testInvalidFunctionName_containsSpace() {
+        XCTAssertFalse(KetchUI.isValidTriggerFunctionName("my function"))
+    }
+
+    func testInvalidFunctionName_containsSpecialCharacter() {
+        XCTAssertFalse(KetchUI.isValidTriggerFunctionName("my/function"))
+        XCTAssertFalse(KetchUI.isValidTriggerFunctionName("my'function"))
+        XCTAssertFalse(KetchUI.isValidTriggerFunctionName("<script>"))
+    }
+
+    func testTriggerNameRawValue_customMatchesJSShape() {
+        XCTAssertEqual(TriggerName.custom.rawValue, "custom")
+    }
+}

--- a/Tests/KetchSDKTests/TriggerValidationTests.swift
+++ b/Tests/KetchSDKTests/TriggerValidationTests.swift
@@ -31,4 +31,90 @@ final class TriggerValidationTests: XCTestCase {
     func testTriggerNameRawValue_customMatchesJSShape() {
         XCTAssertEqual(TriggerName.custom.rawValue, "custom")
     }
+
+    // MARK: - Trigger state machine
+    //
+    // These drive KetchUI's private bridge-event handler directly, since there is no seam for
+    // injecting a fake WebPresentationItem to exercise the real .configurationLoaded flow.
+
+    private func makeKetchUI() -> KetchUI {
+        let ketch = Ketch(organizationCode: "acme", propertyCode: "prop", environmentCode: "production", identities: [])
+        return KetchUI(ketch: ketch)
+    }
+
+    private let emptyConfiguration = KetchSDK.Configuration(
+        experiences: nil,
+        theme: nil,
+        rights: nil,
+        jurisdiction: nil,
+        purposes: nil
+    )
+
+    func testTrigger_beforeTagBoots_queuesRatherThanFiring() {
+        let ketchUI = makeKetchUI()
+        XCTAssertFalse(ketchUI.isTagBooted)
+
+        let accepted = ketchUI.trigger(triggerName: .custom, functionName: "testFn")
+
+        XCTAssertTrue(accepted)
+        XCTAssertNotNil(ketchUI.pendingTrigger)
+    }
+
+    func testTrigger_afterTagBoots_firesImmediatelyWithoutQueueing() {
+        let ketchUI = makeKetchUI()
+        ketchUI.handle(webPresentationEvent: .configurationLoaded(emptyConfiguration))
+        XCTAssertTrue(ketchUI.isTagBooted)
+
+        let accepted = ketchUI.trigger(triggerName: .custom, functionName: "testFn")
+
+        XCTAssertTrue(accepted)
+        XCTAssertNil(ketchUI.pendingTrigger)
+    }
+
+    func testConfigurationLoaded_drainsAPreviouslyQueuedTrigger() {
+        let ketchUI = makeKetchUI()
+        _ = ketchUI.trigger(triggerName: .custom, functionName: "testFn")
+        XCTAssertNotNil(ketchUI.pendingTrigger)
+
+        ketchUI.handle(webPresentationEvent: .configurationLoaded(emptyConfiguration))
+
+        XCTAssertNil(ketchUI.pendingTrigger)
+    }
+
+    func testConfigurationLoaded_deferredShow_leavesTagBootedTrue() {
+        // Regression test: a deferred first show used to reset isTagBooted (then isConfigLoaded)
+        // back to false, so every later trigger() queued forever and never fired.
+        let ketchUI = makeKetchUI()
+        ketchUI.showConsent() // defers, since the tag hasn't booted yet
+
+        ketchUI.handle(webPresentationEvent: .configurationLoaded(emptyConfiguration))
+
+        XCTAssertTrue(ketchUI.isTagBooted)
+    }
+
+    func testReload_resetsTagBootedState() {
+        let ketchUI = makeKetchUI()
+        ketchUI.handle(webPresentationEvent: .configurationLoaded(emptyConfiguration))
+        XCTAssertTrue(ketchUI.isTagBooted)
+
+        ketchUI.reload()
+
+        XCTAssertFalse(
+            ketchUI.isTagBooted,
+            "a trigger() issued during the reload window must take the cold path, not evaluate JS against a page that hasn't loaded yet"
+        )
+    }
+
+    func testReload_preservesAPendingTrigger() {
+        let ketchUI = makeKetchUI()
+        _ = ketchUI.trigger(triggerName: .custom, functionName: "testFn")
+        XCTAssertNotNil(ketchUI.pendingTrigger)
+
+        ketchUI.reload()
+
+        XCTAssertNotNil(
+            ketchUI.pendingTrigger,
+            "the caller was already told trigger() returned true; a reload must not silently discard it"
+        )
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Code generated by shipbuilder init 1.21.3. DO NOT EDIT. -->

## Description of this change

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

Adds `onFunction` rule trigger support: `TriggerName.swift`, the `PresentationItem.trigger` method, and `TriggerValidationTests.swift`. This is the topmost layer touching `KetchUI.swift`, landing it in full.

Part 7/9 of the split of #76.

Also fixes the trigger state machine: a reload didn't reset the tag-booted flag, so a trigger issued during the reload window evaluated JS against a page that hadn't loaded yet. Separately, a deferred first show incorrectly cleared that same flag, so every trigger after that queued forever and never fired. New tests cover the state machine directly.

## Why is this change being made?

- [ ] Chore (non-functional changes)
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

`xcodebuild -scheme KetchSDK -destination 'generic/platform=iOS Simulator' build` — succeeded.

## Related issues

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Refs #76 — layer 7 of 9 in the split of #76.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.