### PR TITLE
test: cover headless API client and consent paths

### DIFF
--- a/Tests/KetchSDKTests/FullConfigurationRequestTests.swift
+++ b/Tests/KetchSDKTests/FullConfigurationRequestTests.swift
@@ -1,0 +1,173 @@
+import XCTest
+@testable import KetchSDK
+
+final class FullConfigurationRequestTests: XCTestCase {
+    func testConfigPathSegment_allPresentAndNonBlank_returnsSegment() {
+        let request = KetchSDK.FullConfigurationRequest(
+            organizationCode: "acme",
+            propertyCode: "prop",
+            environmentCode: "production",
+            jurisdictionCode: "us-ca",
+            languageCode: "en-US"
+        )
+        let segment = request.configPathSegment()
+        XCTAssertEqual(segment?.env, "production")
+        XCTAssertEqual(segment?.jurisdiction, "us-ca")
+        XCTAssertEqual(segment?.language, "en-US")
+    }
+
+    func testConfigPathSegment_nilField_returnsNil() {
+        let request = KetchSDK.FullConfigurationRequest(
+            organizationCode: "acme",
+            propertyCode: "prop",
+            environmentCode: nil,
+            jurisdictionCode: "us-ca",
+            languageCode: "en-US"
+        )
+        XCTAssertNil(request.configPathSegment())
+    }
+
+    func testConfigPathSegment_blankField_treatedAsAbsent() {
+        let request = KetchSDK.FullConfigurationRequest(
+            organizationCode: "acme",
+            propertyCode: "prop",
+            environmentCode: "",
+            jurisdictionCode: "us-ca",
+            languageCode: "en-US"
+        )
+        XCTAssertNil(request.configPathSegment(), "A blank environmentCode must be treated the same as nil")
+    }
+
+    func testConfigPathSegment_blankJurisdiction_treatedAsAbsent() {
+        let request = KetchSDK.FullConfigurationRequest(
+            organizationCode: "acme",
+            propertyCode: "prop",
+            environmentCode: "production",
+            jurisdictionCode: "",
+            languageCode: "en-US"
+        )
+        XCTAssertNil(request.configPathSegment())
+    }
+
+    func testConfigPathSegment_blankLanguage_treatedAsAbsent() {
+        let request = KetchSDK.FullConfigurationRequest(
+            organizationCode: "acme",
+            propertyCode: "prop",
+            environmentCode: "production",
+            jurisdictionCode: "us-ca",
+            languageCode: ""
+        )
+        XCTAssertNil(request.configPathSegment())
+    }
+
+    func testNormalizedHash_present_returnsHash() {
+        let request = KetchSDK.FullConfigurationRequest(
+            organizationCode: "acme",
+            propertyCode: "prop",
+            hash: "123"
+        )
+        XCTAssertEqual(request.normalizedHash(), "123")
+    }
+
+    func testNormalizedHash_nil_returnsNil() {
+        let request = KetchSDK.FullConfigurationRequest(organizationCode: "acme", propertyCode: "prop")
+        XCTAssertNil(request.normalizedHash())
+    }
+
+    func testNormalizedHash_blank_treatedAsAbsent() {
+        let request = KetchSDK.FullConfigurationRequest(
+            organizationCode: "acme",
+            propertyCode: "prop",
+            hash: ""
+        )
+        XCTAssertNil(request.normalizedHash())
+    }
+
+    func testFormatLanguageTag_underscoreSeparator_becomesHyphenWithUppercaseDialect() {
+        XCTAssertEqual(KetchSDK.FullConfigurationRequest.formatLanguageTag("fr_CA"), "fr-CA")
+    }
+
+    func testFormatLanguageTag_lowercaseDialect_isUppercased() {
+        XCTAssertEqual(KetchSDK.FullConfigurationRequest.formatLanguageTag("fr-ca"), "fr-CA")
+    }
+
+    func testFormatLanguageTag_rootOnly_isLowercased() {
+        XCTAssertEqual(KetchSDK.FullConfigurationRequest.formatLanguageTag("EN"), "en")
+    }
+
+    func testFormatLanguageTag_blank_fallsBackToEnglish() {
+        XCTAssertEqual(KetchSDK.FullConfigurationRequest.formatLanguageTag(""), "en")
+    }
+
+    func testConfigQueryItems_allPresent_onlyIncludesHash() {
+        let request = KetchSDK.FullConfigurationRequest(
+            organizationCode: "acme",
+            propertyCode: "prop",
+            environmentCode: "production",
+            jurisdictionCode: "us-ca",
+            languageCode: "en-US",
+            hash: "abc123"
+        )
+        XCTAssertEqual(request.configQueryItems(deviceLanguage: { "fr-CA" }), [URLQueryItem(name: "hash", value: "abc123")])
+    }
+
+    func testConfigQueryItems_allPresent_noHash_isEmpty() {
+        let request = KetchSDK.FullConfigurationRequest(
+            organizationCode: "acme",
+            propertyCode: "prop",
+            environmentCode: "production",
+            jurisdictionCode: "us-ca",
+            languageCode: "en-US"
+        )
+        XCTAssertEqual(request.configQueryItems(deviceLanguage: { "fr-CA" }), [])
+    }
+
+    func testConfigQueryItems_nothingSet_defaultsLanguageFromDevice() {
+        let request = KetchSDK.FullConfigurationRequest(organizationCode: "acme", propertyCode: "prop")
+        XCTAssertEqual(request.configQueryItems(deviceLanguage: { "fr-CA" }), [URLQueryItem(name: "language", value: "fr-CA")])
+    }
+
+    func testConfigQueryItems_explicitLanguage_winsOverDeviceLocale() {
+        let request = KetchSDK.FullConfigurationRequest(
+            organizationCode: "acme",
+            propertyCode: "prop",
+            languageCode: "de-DE"
+        )
+        XCTAssertEqual(request.configQueryItems(deviceLanguage: { "fr-CA" }), [URLQueryItem(name: "language", value: "de-DE")])
+    }
+
+    func testConfigQueryItems_jurisdictionOnly_includesJurisdictionAndDefaultedLanguage() {
+        let request = KetchSDK.FullConfigurationRequest(
+            organizationCode: "acme",
+            propertyCode: "prop",
+            jurisdictionCode: "us-ca"
+        )
+        XCTAssertEqual(
+            request.configQueryItems(deviceLanguage: { "fr-CA" }),
+            [URLQueryItem(name: "language", value: "fr-CA"), URLQueryItem(name: "jurisdiction", value: "us-ca")]
+        )
+    }
+
+    func testConfigQueryItems_regionOnly_includesRegionAndDefaultedLanguage() {
+        let request = KetchSDK.FullConfigurationRequest(
+            organizationCode: "acme",
+            propertyCode: "prop",
+            regionCode: "US-CA"
+        )
+        XCTAssertEqual(
+            request.configQueryItems(deviceLanguage: { "fr-CA" }),
+            [URLQueryItem(name: "language", value: "fr-CA"), URLQueryItem(name: "region", value: "US-CA")]
+        )
+    }
+
+    func testConfigQueryItems_blankFieldsTreatedAsAbsent() {
+        let request = KetchSDK.FullConfigurationRequest(
+            organizationCode: "acme",
+            propertyCode: "prop",
+            jurisdictionCode: "",
+            hash: "",
+            regionCode: ""
+        )
+        XCTAssertEqual(request.configQueryItems(deviceLanguage: { "fr-CA" }), [URLQueryItem(name: "language", value: "fr-CA")])
+    }
+}

--- a/Tests/KetchSDKTests/FullConfigurationRequestTests.swift
+++ b/Tests/KetchSDKTests/FullConfigurationRequestTests.swift
@@ -164,6 +164,15 @@ final class FullConfigurationRequestTests: XCTestCase {
         XCTAssertEqual(request.configQueryItems(deviceLanguage: { "fr-CA" }), [URLQueryItem(name: "language", value: "de-DE")])
     }
 
+    func testConfigQueryItems_explicitLanguage_normalized() {
+        let request = KetchSDK.FullConfigurationRequest(
+            organizationCode: "acme",
+            propertyCode: "prop",
+            languageCode: "fr_ca"
+        )
+        XCTAssertEqual(request.configQueryItems(deviceLanguage: { "en" }), [URLQueryItem(name: "language", value: "fr-CA")])
+    }
+
     func testConfigQueryItems_jurisdictionOnly_includesJurisdictionAndDefaultedLanguage() {
         let request = KetchSDK.FullConfigurationRequest(
             organizationCode: "acme",

--- a/Tests/KetchSDKTests/FullConfigurationRequestTests.swift
+++ b/Tests/KetchSDKTests/FullConfigurationRequestTests.swift
@@ -49,7 +49,7 @@ final class FullConfigurationRequestTests: XCTestCase {
         XCTAssertNil(request.configPathSegment())
     }
 
-    func testConfigPathSegment_blankLanguage_treatedAsAbsent() {
+    func testConfigPathSegment_blankLanguage_synthesizesDeviceLanguage() {
         let request = KetchSDK.FullConfigurationRequest(
             organizationCode: "acme",
             propertyCode: "prop",
@@ -57,7 +57,7 @@ final class FullConfigurationRequestTests: XCTestCase {
             jurisdictionCode: "us-ca",
             languageCode: ""
         )
-        XCTAssertNil(request.configPathSegment())
+        XCTAssertEqual(request.configPathSegment()?.language, KetchSDK.FullConfigurationRequest.deviceLanguageTag())
     }
 
     func testNormalizedHash_present_returnsHash() {
@@ -97,6 +97,34 @@ final class FullConfigurationRequestTests: XCTestCase {
 
     func testFormatLanguageTag_blank_fallsBackToEnglish() {
         XCTAssertEqual(KetchSDK.FullConfigurationRequest.formatLanguageTag(""), "en")
+    }
+
+    func testFormatLanguageTag_scriptAndRegion_bothPreserved() {
+        // A naive split-on-first-separator collapses this to "zh-HANS", dropping the region.
+        XCTAssertEqual(KetchSDK.FullConfigurationRequest.formatLanguageTag("zh-Hans-CN"), "zh-Hans-CN")
+    }
+
+    func testFormatLanguageTag_scriptOnly_titleCased() {
+        XCTAssertEqual(KetchSDK.FullConfigurationRequest.formatLanguageTag("zh-hans"), "zh-Hans")
+    }
+
+    func testFormatLanguageTag_numericRegion_uppercasedNoOp() {
+        XCTAssertEqual(KetchSDK.FullConfigurationRequest.formatLanguageTag("es-419"), "es-419")
+    }
+
+    func testConfigPathSegment_environmentAndJurisdictionSet_languageMissing_synthesizesDeviceLanguage() {
+        // Environment/jurisdiction must not be silently dropped to the short path just because
+        // the caller didn't also supply an explicit language.
+        let request = KetchSDK.FullConfigurationRequest(
+            organizationCode: "acme",
+            propertyCode: "prop",
+            environmentCode: "production",
+            jurisdictionCode: "us-ca"
+        )
+        let segment = request.configPathSegment()
+        XCTAssertEqual(segment?.env, "production")
+        XCTAssertEqual(segment?.jurisdiction, "us-ca")
+        XCTAssertEqual(segment?.language, KetchSDK.FullConfigurationRequest.deviceLanguageTag())
     }
 
     func testConfigQueryItems_allPresent_onlyIncludesHash() {

--- a/Tests/KetchSDKTests/HeadlessApiClientTests.swift
+++ b/Tests/KetchSDKTests/HeadlessApiClientTests.swift
@@ -1,0 +1,267 @@
+import Combine
+import XCTest
+@testable import KetchSDK
+
+final class HeadlessApiClientTests: XCTestCase {
+    private var client: HeadlessApiClient!
+    private var cancellables = Set<AnyCancellable>()
+
+    override func setUp() {
+        super.setUp()
+        client = HeadlessApiClient(dataCenter: .us)
+    }
+
+    func testBuildURL_ip() {
+        let url = client.buildURL(path: "/ip")
+        XCTAssertEqual(url?.absoluteString, "https://global.ketchcdn.com/web/v3/ip")
+    }
+
+    func testBuildURL_bootstrap() {
+        let url = client.buildURL(path: "/config/acme/prop/boot.json")
+        XCTAssertEqual(
+            url?.absoluteString,
+            "https://global.ketchcdn.com/web/v3/config/acme/prop/boot.json"
+        )
+    }
+
+    func testFetchConfig_includesPreferredLanguageQueryParam() throws {
+        let preferredLanguage = KetchSDK.FullConfigurationRequest.formatLanguageTag(Locale.preferredLanguages[0])
+        var capturedURL: URL?
+        let apiClient = CapturingApiClient { request in
+            capturedURL = request.endPoint.url
+            return Just(Data("{}".utf8))
+                .setFailureType(to: ApiClientError.self)
+                .eraseToAnyPublisher()
+        }
+        let client = HeadlessApiClient(dataCenter: .us, apiClient: apiClient)
+
+        let expectation = expectation(description: "fetchConfig language query")
+        client.fetchConfig(organization: "acme", property: "prop")
+            .sink(
+                receiveCompletion: { completion in
+                    if case .failure(let error) = completion {
+                        XCTFail("fetchConfig failed: \(error)")
+                    }
+                    expectation.fulfill()
+                },
+                receiveValue: { _ in }
+            )
+            .store(in: &cancellables)
+        wait(for: [expectation], timeout: 5)
+
+        let url = try XCTUnwrap(capturedURL)
+        XCTAssertEqual(url.path, "/web/v3/config/acme/prop/config.json")
+        XCTAssertEqual(
+            URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems,
+            [URLQueryItem(name: "language", value: preferredLanguage)]
+        )
+    }
+
+    func testGetFullConfiguration_blankEnvironment_omittedFromPath() throws {
+        var capturedURL: URL?
+        let apiClient = CapturingApiClient { request in
+            capturedURL = request.endPoint.url
+            return Just(Data("{}".utf8))
+                .setFailureType(to: ApiClientError.self)
+                .eraseToAnyPublisher()
+        }
+        let client = HeadlessApiClient(dataCenter: .us, apiClient: apiClient)
+
+        let expectation = expectation(description: "getFullConfiguration blank env")
+        client.getFullConfiguration(
+            request: .init(
+                organizationCode: "acme",
+                propertyCode: "prop",
+                environmentCode: "", // blank — must be treated as absent, not embedded as an empty path segment
+                jurisdictionCode: "us-ca",
+                languageCode: "en-US"
+            )
+        )
+        .sink(
+            receiveCompletion: { completion in
+                if case .failure(let error) = completion {
+                    XCTFail("getFullConfiguration failed: \(error)")
+                }
+                expectation.fulfill()
+            },
+            receiveValue: { _ in }
+        )
+        .store(in: &cancellables)
+        wait(for: [expectation], timeout: 5)
+
+        let url = try XCTUnwrap(capturedURL)
+        // A blank environmentCode must not produce a malformed path like ".../prop//us-ca/en-US/config.json".
+        XCTAssertEqual(url.path, "/web/v3/config/acme/prop/config.json")
+        XCTAssertEqual(
+            URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems,
+            [URLQueryItem(name: "language", value: "en-US"), URLQueryItem(name: "jurisdiction", value: "us-ca")]
+        )
+    }
+
+    func testGetFullConfiguration_nothingSet_shortPath_includesDeviceLanguage() throws {
+        var capturedURL: URL?
+        let apiClient = CapturingApiClient { request in
+            capturedURL = request.endPoint.url
+            return Just(Data("{}".utf8)).setFailureType(to: ApiClientError.self).eraseToAnyPublisher()
+        }
+        let client = HeadlessApiClient(dataCenter: .us, apiClient: apiClient)
+
+        let expectation = expectation(description: "getFullConfiguration nothing set")
+        client.getFullConfiguration(request: .init(organizationCode: "acme", propertyCode: "prop"))
+            .sink(
+                receiveCompletion: { completion in
+                    if case .failure(let error) = completion { XCTFail("getFullConfiguration failed: \(error)") }
+                    expectation.fulfill()
+                },
+                receiveValue: { _ in }
+            )
+            .store(in: &cancellables)
+        wait(for: [expectation], timeout: 5)
+
+        let url = try XCTUnwrap(capturedURL)
+        let deviceLanguage = KetchSDK.FullConfigurationRequest.formatLanguageTag(Locale.preferredLanguages[0])
+        XCTAssertEqual(url.path, "/web/v3/config/acme/prop/config.json")
+        XCTAssertEqual(
+            URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems,
+            [URLQueryItem(name: "language", value: deviceLanguage)]
+        )
+    }
+
+    func testGetFullConfiguration_explicitLanguage_winsOverDeviceLocale() throws {
+        var capturedURL: URL?
+        let apiClient = CapturingApiClient { request in
+            capturedURL = request.endPoint.url
+            return Just(Data("{}".utf8)).setFailureType(to: ApiClientError.self).eraseToAnyPublisher()
+        }
+        let client = HeadlessApiClient(dataCenter: .us, apiClient: apiClient)
+
+        let expectation = expectation(description: "getFullConfiguration explicit language")
+        client.getFullConfiguration(request: .init(organizationCode: "acme", propertyCode: "prop", languageCode: "de-DE"))
+            .sink(
+                receiveCompletion: { completion in
+                    if case .failure(let error) = completion { XCTFail("getFullConfiguration failed: \(error)") }
+                    expectation.fulfill()
+                },
+                receiveValue: { _ in }
+            )
+            .store(in: &cancellables)
+        wait(for: [expectation], timeout: 5)
+
+        let url = try XCTUnwrap(capturedURL)
+        XCTAssertEqual(
+            URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems,
+            [URLQueryItem(name: "language", value: "de-DE")]
+        )
+    }
+
+    func testGetFullConfiguration_blankHash_omittedFromQuery() throws {
+        var capturedURL: URL?
+        let apiClient = CapturingApiClient { request in
+            capturedURL = request.endPoint.url
+            return Just(Data("{}".utf8))
+                .setFailureType(to: ApiClientError.self)
+                .eraseToAnyPublisher()
+        }
+        let client = HeadlessApiClient(dataCenter: .us, apiClient: apiClient)
+
+        let expectation = expectation(description: "getFullConfiguration blank hash")
+        client.getFullConfiguration(
+            request: .init(
+                organizationCode: "acme",
+                propertyCode: "prop",
+                environmentCode: "production",
+                jurisdictionCode: "us-ca",
+                languageCode: "en-US",
+                hash: ""
+            )
+        )
+        .sink(
+            receiveCompletion: { completion in
+                if case .failure(let error) = completion {
+                    XCTFail("getFullConfiguration failed: \(error)")
+                }
+                expectation.fulfill()
+            },
+            receiveValue: { _ in }
+        )
+        .store(in: &cancellables)
+        wait(for: [expectation], timeout: 5)
+
+        let url = try XCTUnwrap(capturedURL)
+        XCTAssertNil(URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems, "A blank hash must not appear as a query param")
+    }
+
+    func testBuildURL_fullConfigurationWithHash() {
+        let url = client.buildURL(
+            path: "/config/acme/prop/prod/us-ca/en-US/config.json",
+            queryItems: [URLQueryItem(name: "hash", value: "8913461971881236311")]
+        )
+        XCTAssertEqual(
+            url?.absoluteString,
+            "https://global.ketchcdn.com/web/v3/config/acme/prop/prod/us-ca/en-US/config.json?hash=8913461971881236311"
+        )
+    }
+
+    func testBuildURL_euDataCenter() {
+        let eu = HeadlessApiClient(dataCenter: .eu)
+        let url = eu.buildURL(path: "/ip")
+        XCTAssertEqual(url?.absoluteString, "https://eu.ketchcdn.com/web/v3/ip")
+    }
+
+    func testGetPreferenceQRUrl_matchesContractFixture() {
+        let url = client.getPreferenceQRUrl(
+            request: .init(
+                organizationCode: "switchbitcorp",
+                propertyCode: "switchbit",
+                environmentCode: "production",
+                imageSize: 1024,
+                path: "/policy.html",
+                backgroundColor: "white",
+                foregroundColor: "black",
+                parameters: ["foo": "bar"]
+            )
+        )
+        XCTAssertEqual(
+            url?.absoluteString,
+            "https://global.ketchcdn.com/web/v3/qr/switchbitcorp/switchbit/preferences.png?env=production&size=1024&path=%2Fpolicy.html&bgcolor=white&fgcolor=black&foo=bar"
+        )
+    }
+
+    func testBuildURL_rightsProfileSubscriptions() {
+        let invoke = client.buildURL(path: "/rights/switchbitcorp/invoke")
+        XCTAssertEqual(
+            invoke?.absoluteString,
+            "https://global.ketchcdn.com/web/v3/rights/switchbitcorp/invoke"
+        )
+        let profile = client.buildURL(path: "/profile/acme/get")
+        XCTAssertEqual(
+            profile?.absoluteString,
+            "https://global.ketchcdn.com/web/v3/profile/acme/get"
+        )
+        let subs = client.buildURL(path: "/subscriptions/acme/update")
+        XCTAssertEqual(
+            subs?.absoluteString,
+            "https://global.ketchcdn.com/web/v3/subscriptions/acme/update"
+        )
+    }
+
+    func testKetchDataCenterBaseURLs() {
+        XCTAssertEqual(KetchDataCenter.us.baseURL.absoluteString, "https://global.ketchcdn.com/web/v3")
+        XCTAssertEqual(KetchDataCenter.eu.baseURL.absoluteString, "https://eu.ketchcdn.com/web/v3")
+        XCTAssertEqual(KetchDataCenter.uat.baseURL.absoluteString, "https://dev.ketchcdn.com/web/v3")
+    }
+}
+
+// MARK: - Test doubles
+
+private final class CapturingApiClient: ApiClient {
+    private let handler: (ApiRequest) -> AnyPublisher<Data, ApiClientError>
+
+    init(handler: @escaping (ApiRequest) -> AnyPublisher<Data, ApiClientError>) {
+        self.handler = handler
+    }
+
+    func execute(request: ApiRequest) -> AnyPublisher<Data, ApiClientError> {
+        handler(request)
+    }
+}

--- a/Tests/KetchSDKTests/HeadlessApiClientTests.swift
+++ b/Tests/KetchSDKTests/HeadlessApiClientTests.swift
@@ -187,6 +187,38 @@ final class HeadlessApiClientTests: XCTestCase {
         )
     }
 
+    func testGetFullConfiguration_explicitLanguage_normalizedOnLongPath() throws {
+        var capturedURL: URL?
+        let apiClient = CapturingApiClient { request in
+            capturedURL = request.endPoint.url
+            return Just(Data("{}".utf8)).setFailureType(to: ApiClientError.self).eraseToAnyPublisher()
+        }
+        let client = HeadlessApiClient(dataCenter: .us, apiClient: apiClient)
+
+        let expectation = expectation(description: "getFullConfiguration explicit unnormalized language")
+        client.getFullConfiguration(
+            request: .init(
+                organizationCode: "acme",
+                propertyCode: "prop",
+                environmentCode: "production",
+                jurisdictionCode: "us-ca",
+                languageCode: "fr_ca"
+            )
+        )
+        .sink(
+            receiveCompletion: { completion in
+                if case .failure(let error) = completion { XCTFail("getFullConfiguration failed: \(error)") }
+                expectation.fulfill()
+            },
+            receiveValue: { _ in }
+        )
+        .store(in: &cancellables)
+        wait(for: [expectation], timeout: 5)
+
+        let url = try XCTUnwrap(capturedURL)
+        XCTAssertEqual(url.path, "/web/v3/config/acme/prop/production/us-ca/fr-CA/config.json")
+    }
+
     func testGetFullConfiguration_blankHash_omittedFromQuery() throws {
         var capturedURL: URL?
         let apiClient = CapturingApiClient { request in

--- a/Tests/KetchSDKTests/HeadlessApiClientTests.swift
+++ b/Tests/KetchSDKTests/HeadlessApiClientTests.swift
@@ -98,6 +98,39 @@ final class HeadlessApiClientTests: XCTestCase {
         )
     }
 
+    func testGetFullConfiguration_environmentAndJurisdictionSet_languageMissing_takesLongPath() throws {
+        // Environment/jurisdiction must not be silently dropped to the short path just because
+        // the caller didn't also supply an explicit language.
+        var capturedURL: URL?
+        let apiClient = CapturingApiClient { request in
+            capturedURL = request.endPoint.url
+            return Just(Data("{}".utf8))
+                .setFailureType(to: ApiClientError.self)
+                .eraseToAnyPublisher()
+        }
+        let client = HeadlessApiClient(dataCenter: .us, apiClient: apiClient)
+
+        let expectation = expectation(description: "getFullConfiguration language missing")
+        client.getFullConfiguration(
+            request: .init(organizationCode: "acme", propertyCode: "prop", environmentCode: "production", jurisdictionCode: "us-ca")
+        )
+        .sink(
+            receiveCompletion: { completion in
+                if case .failure(let error) = completion {
+                    XCTFail("getFullConfiguration failed: \(error)")
+                }
+                expectation.fulfill()
+            },
+            receiveValue: { _ in }
+        )
+        .store(in: &cancellables)
+        wait(for: [expectation], timeout: 5)
+
+        let url = try XCTUnwrap(capturedURL)
+        let deviceLanguage = KetchSDK.FullConfigurationRequest.deviceLanguageTag()
+        XCTAssertEqual(url.path, "/web/v3/config/acme/prop/production/us-ca/\(deviceLanguage)/config.json")
+    }
+
     func testGetFullConfiguration_nothingSet_shortPath_includesDeviceLanguage() throws {
         var capturedURL: URL?
         let apiClient = CapturingApiClient { request in

--- a/Tests/KetchSDKTests/HeadlessCdnIntegrationTests.swift
+++ b/Tests/KetchSDKTests/HeadlessCdnIntegrationTests.swift
@@ -1,0 +1,112 @@
+import Combine
+import XCTest
+@testable import KetchSDK
+
+/// Live CDN headless round-trip tests (web/v3, sandbox org).
+///
+/// Run with network enabled:
+/// `KETCH_INTEGRATION_TESTS=1 xcodebuild -scheme KetchSDK -destination 'platform=iOS Simulator,name=iPhone 17' test -only-testing:KetchSDKTests/HeadlessCdnIntegrationTests`
+final class HeadlessCdnIntegrationTests: XCTestCase {
+    private var client: HeadlessApiClient!
+    private var cancellables: Set<AnyCancellable> = []
+
+    override func setUp() {
+        super.setUp()
+        try? XCTSkipUnless(
+            ProcessInfo.processInfo.environment["KETCH_INTEGRATION_TESTS"] == "1",
+            "Set KETCH_INTEGRATION_TESTS=1 to run live CDN tests"
+        )
+        client = HeadlessApiClient(dataCenter: .us)
+        cancellables = []
+    }
+
+    override func tearDown() {
+        cancellables.removeAll()
+        super.tearDown()
+    }
+
+    func testFetchLocationReturnsGeoIP() {
+        let expectation = expectation(description: "getLocation")
+        client.getLocation()
+            .sink(
+                receiveCompletion: { completion in
+                    if case .failure(let error) = completion {
+                        XCTFail("getLocation failed: \(error)")
+                    }
+                    expectation.fulfill()
+                },
+                receiveValue: { response in
+                    XCTAssertFalse(response.location?.countryCode?.isEmpty ?? true)
+                }
+            )
+            .store(in: &cancellables)
+        wait(for: [expectation], timeout: 45)
+    }
+
+    func testFetchBootstrapConfiguration() {
+        let expectation = expectation(description: "getBootstrapConfiguration")
+        client.getBootstrapConfiguration(
+            organization: HeadlessIntegrationSupport.orgCode,
+            property: HeadlessIntegrationSupport.propertyCode
+        )
+        .sink(
+            receiveCompletion: { completion in
+                if case .failure(let error) = completion {
+                    XCTFail("getBootstrapConfiguration failed: \(error)")
+                }
+                expectation.fulfill()
+            },
+            receiveValue: { boot in
+                let hasMetadata = boot.experiences != nil
+                    || boot.jurisdiction != nil
+                    || !(boot.purposes?.isEmpty ?? true)
+                XCTAssertTrue(hasMetadata, "Bootstrap should include experiences metadata")
+            }
+        )
+        .store(in: &cancellables)
+        wait(for: [expectation], timeout: 45)
+    }
+
+    func testHeadlessColdStartConsentRoundTrip() {
+        let identities = HeadlessIntegrationSupport.uniqueEmailIdentity()
+        let expectation = expectation(description: "coldStart")
+
+        client.getBootstrapConfiguration(
+            organization: HeadlessIntegrationSupport.orgCode,
+            property: HeadlessIntegrationSupport.propertyCode
+        )
+        .flatMap { _ in
+            self.client.getFullConfiguration(
+                request: .init(
+                    organizationCode: HeadlessIntegrationSupport.orgCode,
+                    propertyCode: HeadlessIntegrationSupport.propertyCode
+                )
+            )
+        }
+        .map { full in
+            HeadlessIntegrationSupport.consentConfigFrom(
+                configuration: full,
+                identities: identities
+            )
+        }
+        .flatMap { config in
+            self.client.getConsent(config: config)
+        }
+        .sink(
+            receiveCompletion: { completion in
+                if case .failure(let error) = completion {
+                    XCTFail("cold start failed: \(error)")
+                }
+                expectation.fulfill()
+            },
+            receiveValue: { consent in
+                let hasProtocols = !(consent.protocols?.isEmpty ?? true)
+                let hasPurposes = !(consent.purposes?.isEmpty ?? true)
+                XCTAssertTrue(hasProtocols || hasPurposes, "Expected protocols and/or purposes from CDN")
+            }
+        )
+        .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 60)
+    }
+}

--- a/Tests/KetchSDKTests/HeadlessCdnIntegrationTests.swift
+++ b/Tests/KetchSDKTests/HeadlessCdnIntegrationTests.swift
@@ -10,9 +10,9 @@ final class HeadlessCdnIntegrationTests: XCTestCase {
     private var client: HeadlessApiClient!
     private var cancellables: Set<AnyCancellable> = []
 
-    override func setUp() {
-        super.setUp()
-        try? XCTSkipUnless(
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        try XCTSkipUnless(
             ProcessInfo.processInfo.environment["KETCH_INTEGRATION_TESTS"] == "1",
             "Set KETCH_INTEGRATION_TESTS=1 to run live CDN tests"
         )

--- a/Tests/KetchSDKTests/HeadlessConsentTests.swift
+++ b/Tests/KetchSDKTests/HeadlessConsentTests.swift
@@ -1,0 +1,319 @@
+import Combine
+import XCTest
+@testable import KetchSDK
+
+final class HeadlessConsentTests: XCTestCase {
+    private var cancellables: Set<AnyCancellable> = []
+
+    override func tearDown() {
+        cancellables.removeAll()
+        StubURLProtocol.handler = nil
+        super.tearDown()
+    }
+    func testSetConsentPayloadOmitsProtocols() throws {
+        let update = KetchSDK.ConsentUpdate(
+            organizationCode: "org",
+            propertyCode: "prop",
+            environmentCode: "production",
+            identities: ["id": "1"],
+            jurisdictionCode: "default",
+            migrationOption: .migrateDefault,
+            purposes: [
+                "analytics": .init(allowed: true, legalBasisCode: "consent_optin"),
+            ],
+            vendors: nil,
+            protocols: ["gpp": "DBABLA~"]
+        )
+        let payload = SetConsentPayloadForTesting(update: update)
+        let data = try JSONEncoder().encode(payload)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertNil(json["protocols"])
+        XCTAssertEqual(json["organizationCode"] as? String, "org")
+    }
+
+    func testFetchConsentPropagatesHTTPFailure() {
+        let session = makeStubSession()
+        let client = HeadlessApiClient(dataCenter: .us, session: session)
+        StubURLProtocol.handler = { _ in
+            let response = HTTPURLResponse(
+                url: URL(string: "https://global.ketchcdn.com/web/v3/consent/org/get")!,
+                statusCode: 500,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data())
+        }
+
+        let expectation = expectation(description: "getConsent failure")
+        client.getConsent(config: sampleConsentConfig())
+            .sink(
+                receiveCompletion: { completion in
+                    if case .failure = completion {
+                        expectation.fulfill()
+                    } else {
+                        XCTFail("Expected getConsent to fail on HTTP 500")
+                    }
+                },
+                receiveValue: { _ in
+                    XCTFail("Expected no value on HTTP 500")
+                }
+            )
+            .store(in: &cancellables)
+        wait(for: [expectation], timeout: 5)
+    }
+
+    func testSetConsentPropagatesNetworkFailure() {
+        let session = makeStubSession()
+        let client = HeadlessApiClient(dataCenter: .us, session: session)
+        StubURLProtocol.handler = { _ in
+            throw URLError(.notConnectedToInternet)
+        }
+
+        let expectation = expectation(description: "setConsent failure")
+        client.setConsent(update: sampleConsentUpdate())
+            .sink(
+                receiveCompletion: { completion in
+                    if case .failure = completion {
+                        expectation.fulfill()
+                    } else {
+                        XCTFail("Expected setConsent to fail on network error")
+                    }
+                },
+                receiveValue: { _ in
+                    XCTFail("Expected no value on network error")
+                }
+            )
+            .store(in: &cancellables)
+        wait(for: [expectation], timeout: 5)
+    }
+
+    func testSetConsentAcceptsProtocolsOnlyResponse() throws {
+        let session = makeStubSession()
+        let client = HeadlessApiClient(dataCenter: .us, session: session)
+        let body = """
+        {"protocols":{"gpp":"DBABLA~BVQqAAAAAAJY.QA"}}
+        """
+        StubURLProtocol.handler = { _ in
+            let response = HTTPURLResponse(
+                url: URL(string: "https://global.ketchcdn.com/web/v3/consent/org/update")!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data(body.utf8))
+        }
+
+        let expectation = expectation(description: "setConsent protocols")
+        client.setConsent(update: sampleConsentUpdate())
+            .sink(
+                receiveCompletion: { completion in
+                    if case .failure(let error) = completion {
+                        XCTFail("setConsent failed: \(error)")
+                    }
+                    expectation.fulfill()
+                },
+                receiveValue: { status in
+                    XCTAssertNil(status.purposes)
+                    XCTAssertEqual(status.protocols?["gpp"], "DBABLA~BVQqAAAAAAJY.QA")
+                }
+            )
+            .store(in: &cancellables)
+        wait(for: [expectation], timeout: 5)
+    }
+
+    func testSetConsentFallsBackToCallerProtocolsWhenResponseOmitsThem() throws {
+        let session = makeStubSession()
+        let client = HeadlessApiClient(dataCenter: .us, session: session)
+        let body = """
+        {"purposes":{"analytics":true}}
+        """
+        StubURLProtocol.handler = { _ in
+            let response = HTTPURLResponse(
+                url: URL(string: "https://global.ketchcdn.com/web/v3/consent/org/update")!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data(body.utf8))
+        }
+
+        var update = sampleConsentUpdate()
+        update = .init(
+            organizationCode: update.organizationCode,
+            propertyCode: update.propertyCode,
+            environmentCode: update.environmentCode,
+            identities: update.identities,
+            jurisdictionCode: update.jurisdictionCode,
+            migrationOption: update.migrationOption,
+            purposes: update.purposes,
+            vendors: update.vendors,
+            protocols: ["gpp": "DBABLA~BVQqAAAAAAJY.QA"]
+        )
+
+        let expectation = expectation(description: "setConsent caller protocols")
+        client.setConsent(update: update)
+            .sink(
+                receiveCompletion: { completion in
+                    if case .failure(let error) = completion {
+                        XCTFail("setConsent failed: \(error)")
+                    }
+                    expectation.fulfill()
+                },
+                receiveValue: { status in
+                    XCTAssertEqual(status.purposes?["analytics"], true)
+                    XCTAssertEqual(status.protocols?["gpp"], "DBABLA~BVQqAAAAAAJY.QA")
+                }
+            )
+            .store(in: &cancellables)
+        wait(for: [expectation], timeout: 5)
+    }
+
+    func testFetchConsentAcceptsVendorsOnlyResponse() throws {
+        let session = makeStubSession()
+        let client = HeadlessApiClient(dataCenter: .us, session: session)
+        let body = """
+        {"vendors":["google","meta"]}
+        """
+        StubURLProtocol.handler = { _ in
+            let response = HTTPURLResponse(
+                url: URL(string: "https://global.ketchcdn.com/web/v3/consent/org/get")!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data(body.utf8))
+        }
+
+        let expectation = expectation(description: "getConsent vendors")
+        client.getConsent(config: sampleConsentConfig())
+            .sink(
+                receiveCompletion: { completion in
+                    if case .failure(let error) = completion {
+                        XCTFail("getConsent failed: \(error)")
+                    }
+                    expectation.fulfill()
+                },
+                receiveValue: { status in
+                    XCTAssertNil(status.purposes)
+                    XCTAssertEqual(status.vendors, ["google", "meta"])
+                    XCTAssertNil(status.protocols)
+                }
+            )
+            .store(in: &cancellables)
+        wait(for: [expectation], timeout: 5)
+    }
+
+    func testConsentConfigPayloadOmitsCachedAt() throws {
+        let config = KetchSDK.ConsentConfig(
+            organizationCode: "org",
+            propertyCode: "prop",
+            environmentCode: "production",
+            jurisdictionCode: "default",
+            identities: [:],
+            purposes: [:]
+        )
+        let payload = ConsentConfigPayloadForTesting(config: config)
+        let data = try JSONEncoder().encode(payload)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertNil(json["cachedAt"])
+    }
+}
+
+// MARK: - Consent HTTP stubs
+
+private func makeStubSession() -> URLSession {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [StubURLProtocol.self]
+    return URLSession(configuration: config)
+}
+
+private func sampleConsentConfig() -> KetchSDK.ConsentConfig {
+    .init(
+        organizationCode: "org",
+        propertyCode: "prop",
+        environmentCode: "production",
+        jurisdictionCode: "default",
+        identities: ["email": "user@example.com"],
+        purposes: ["analytics": .init(legalBasisCode: "consent_optin")]
+    )
+}
+
+private func sampleConsentUpdate() -> KetchSDK.ConsentUpdate {
+    .init(
+        organizationCode: "org",
+        propertyCode: "prop",
+        environmentCode: "production",
+        identities: ["email": "user@example.com"],
+        jurisdictionCode: "default",
+        migrationOption: .migrateDefault,
+        purposes: ["analytics": .init(allowed: true, legalBasisCode: "consent_optin")],
+        vendors: nil,
+        protocols: nil
+    )
+}
+
+private final class StubURLProtocol: URLProtocol {
+    static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = Self.handler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.unknown))
+            return
+        }
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+/// Mirrors private `SetConsentPayload` in HeadlessApiClient for contract tests.
+private struct SetConsentPayloadForTesting: Encodable {
+    let organizationCode: String
+    let propertyCode: String
+    let environmentCode: String
+    let identities: [String: String]
+    let jurisdictionCode: String
+    let migrationOption: KetchSDK.ConsentUpdate.MigrationOption
+    let purposes: [String: KetchSDK.ConsentUpdate.PurposeAllowedLegalBasis]
+    let vendors: [String]?
+
+    init(update: KetchSDK.ConsentUpdate) {
+        organizationCode = update.organizationCode
+        propertyCode = update.propertyCode
+        environmentCode = update.environmentCode
+        identities = update.identities
+        jurisdictionCode = update.jurisdictionCode
+        migrationOption = update.migrationOption
+        purposes = update.purposes
+        vendors = update.vendors
+    }
+}
+
+private struct ConsentConfigPayloadForTesting: Encodable {
+    let organizationCode: String
+    let propertyCode: String
+    let environmentCode: String
+    let jurisdictionCode: String
+    let identities: [String: String]
+    let purposes: [String: KetchSDK.ConsentConfig.PurposeLegalBasis]
+
+    init(config: KetchSDK.ConsentConfig) {
+        organizationCode = config.organizationCode
+        propertyCode = config.propertyCode
+        environmentCode = config.environmentCode
+        jurisdictionCode = config.jurisdictionCode
+        identities = config.identities
+        purposes = config.purposes
+    }
+}

--- a/Tests/KetchSDKTests/HeadlessConsentTests.swift
+++ b/Tests/KetchSDKTests/HeadlessConsentTests.swift
@@ -7,7 +7,6 @@ final class HeadlessConsentTests: XCTestCase {
 
     override func tearDown() {
         cancellables.removeAll()
-        StubURLProtocol.handler = nil
         super.tearDown()
     }
     func testSetConsentPayloadOmitsProtocols() throws {
@@ -32,17 +31,9 @@ final class HeadlessConsentTests: XCTestCase {
     }
 
     func testFetchConsentPropagatesHTTPFailure() {
-        let session = makeStubSession()
-        let client = HeadlessApiClient(dataCenter: .us, session: session)
-        StubURLProtocol.handler = { _ in
-            let response = HTTPURLResponse(
-                url: URL(string: "https://global.ketchcdn.com/web/v3/consent/org/get")!,
-                statusCode: 500,
-                httpVersion: nil,
-                headerFields: nil
-            )!
-            return (response, Data())
-        }
+        let client = HeadlessApiClient(dataCenter: .us, apiClient: StubApiClient { _ in
+            Fail(error: .unknownError).eraseToAnyPublisher()
+        })
 
         let expectation = expectation(description: "getConsent failure")
         client.getConsent(config: sampleConsentConfig())
@@ -63,11 +54,9 @@ final class HeadlessConsentTests: XCTestCase {
     }
 
     func testSetConsentPropagatesNetworkFailure() {
-        let session = makeStubSession()
-        let client = HeadlessApiClient(dataCenter: .us, session: session)
-        StubURLProtocol.handler = { _ in
-            throw URLError(.notConnectedToInternet)
-        }
+        let client = HeadlessApiClient(dataCenter: .us, apiClient: StubApiClient { _ in
+            Fail(error: .unknownError).eraseToAnyPublisher()
+        })
 
         let expectation = expectation(description: "setConsent failure")
         client.setConsent(update: sampleConsentUpdate())
@@ -88,20 +77,12 @@ final class HeadlessConsentTests: XCTestCase {
     }
 
     func testSetConsentAcceptsProtocolsOnlyResponse() throws {
-        let session = makeStubSession()
-        let client = HeadlessApiClient(dataCenter: .us, session: session)
         let body = """
         {"protocols":{"gpp":"DBABLA~BVQqAAAAAAJY.QA"}}
         """
-        StubURLProtocol.handler = { _ in
-            let response = HTTPURLResponse(
-                url: URL(string: "https://global.ketchcdn.com/web/v3/consent/org/update")!,
-                statusCode: 200,
-                httpVersion: nil,
-                headerFields: nil
-            )!
-            return (response, Data(body.utf8))
-        }
+        let client = HeadlessApiClient(dataCenter: .us, apiClient: StubApiClient { _ in
+            Just(Data(body.utf8)).setFailureType(to: ApiClientError.self).eraseToAnyPublisher()
+        })
 
         let expectation = expectation(description: "setConsent protocols")
         client.setConsent(update: sampleConsentUpdate())
@@ -122,20 +103,12 @@ final class HeadlessConsentTests: XCTestCase {
     }
 
     func testSetConsentFallsBackToCallerProtocolsWhenResponseOmitsThem() throws {
-        let session = makeStubSession()
-        let client = HeadlessApiClient(dataCenter: .us, session: session)
         let body = """
         {"purposes":{"analytics":true}}
         """
-        StubURLProtocol.handler = { _ in
-            let response = HTTPURLResponse(
-                url: URL(string: "https://global.ketchcdn.com/web/v3/consent/org/update")!,
-                statusCode: 200,
-                httpVersion: nil,
-                headerFields: nil
-            )!
-            return (response, Data(body.utf8))
-        }
+        let client = HeadlessApiClient(dataCenter: .us, apiClient: StubApiClient { _ in
+            Just(Data(body.utf8)).setFailureType(to: ApiClientError.self).eraseToAnyPublisher()
+        })
 
         var update = sampleConsentUpdate()
         update = .init(
@@ -169,20 +142,12 @@ final class HeadlessConsentTests: XCTestCase {
     }
 
     func testFetchConsentAcceptsVendorsOnlyResponse() throws {
-        let session = makeStubSession()
-        let client = HeadlessApiClient(dataCenter: .us, session: session)
         let body = """
         {"vendors":["google","meta"]}
         """
-        StubURLProtocol.handler = { _ in
-            let response = HTTPURLResponse(
-                url: URL(string: "https://global.ketchcdn.com/web/v3/consent/org/get")!,
-                statusCode: 200,
-                httpVersion: nil,
-                headerFields: nil
-            )!
-            return (response, Data(body.utf8))
-        }
+        let client = HeadlessApiClient(dataCenter: .us, apiClient: StubApiClient { _ in
+            Just(Data(body.utf8)).setFailureType(to: ApiClientError.self).eraseToAnyPublisher()
+        })
 
         let expectation = expectation(description: "getConsent vendors")
         client.getConsent(config: sampleConsentConfig())
@@ -221,10 +186,16 @@ final class HeadlessConsentTests: XCTestCase {
 
 // MARK: - Consent HTTP stubs
 
-private func makeStubSession() -> URLSession {
-    let config = URLSessionConfiguration.ephemeral
-    config.protocolClasses = [StubURLProtocol.self]
-    return URLSession(configuration: config)
+private final class StubApiClient: ApiClient {
+    private let handler: (ApiRequest) -> AnyPublisher<Data, ApiClientError>
+
+    init(handler: @escaping (ApiRequest) -> AnyPublisher<Data, ApiClientError>) {
+        self.handler = handler
+    }
+
+    func execute(request: ApiRequest) -> AnyPublisher<Data, ApiClientError> {
+        handler(request)
+    }
 }
 
 private func sampleConsentConfig() -> KetchSDK.ConsentConfig {
@@ -250,31 +221,6 @@ private func sampleConsentUpdate() -> KetchSDK.ConsentUpdate {
         vendors: nil,
         protocols: nil
     )
-}
-
-private final class StubURLProtocol: URLProtocol {
-    static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
-
-    override class func canInit(with request: URLRequest) -> Bool { true }
-
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
-
-    override func startLoading() {
-        guard let handler = Self.handler else {
-            client?.urlProtocol(self, didFailWithError: URLError(.unknown))
-            return
-        }
-        do {
-            let (response, data) = try handler(request)
-            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-            client?.urlProtocol(self, didLoad: data)
-            client?.urlProtocolDidFinishLoading(self)
-        } catch {
-            client?.urlProtocol(self, didFailWithError: error)
-        }
-    }
-
-    override func stopLoading() {}
 }
 
 /// Mirrors private `SetConsentPayload` in HeadlessApiClient for contract tests.

--- a/Tests/KetchSDKTests/HeadlessIntegrationSupport.swift
+++ b/Tests/KetchSDKTests/HeadlessIntegrationSupport.swift
@@ -1,0 +1,45 @@
+import Foundation
+@testable import KetchSDK
+
+/// Shared sandbox config for live CDN integration tests.
+enum HeadlessIntegrationSupport {
+    static let orgCode = "ketch_samples"
+    static let propertyCode = "ios"
+    static let environmentCode = "production"
+
+    static func uniqueEmailIdentity() -> [String: String] {
+        ["email": "headless-\(UUID().uuidString)@integration.ketch.test"]
+    }
+
+    static func consentConfigFrom(
+        configuration: KetchSDK.Configuration,
+        identities: [String: String],
+        organizationCode: String = orgCode,
+        propertyCode: String = propertyCode,
+        environmentCode: String = environmentCode
+    ) -> KetchSDK.ConsentConfig {
+        let jurisdiction = configuration.jurisdiction?.code
+            ?? configuration.jurisdiction?.defaultJurisdictionCode
+            ?? "us"
+        let purposesList = configuration.purposes ?? []
+        let purposeMap = Dictionary(
+            uniqueKeysWithValues: purposesList.map { purpose in
+                (
+                    purpose.code,
+                    KetchSDK.ConsentConfig.PurposeLegalBasis(
+                        legalBasisCode: purpose.legalBasisCode
+                    )
+                )
+            }
+        )
+        precondition(!purposeMap.isEmpty, "Configuration returned no purposes")
+        return KetchSDK.ConsentConfig(
+            organizationCode: organizationCode,
+            propertyCode: propertyCode,
+            environmentCode: environmentCode,
+            jurisdictionCode: jurisdiction,
+            identities: identities,
+            purposes: purposeMap
+        )
+    }
+}

--- a/Tests/KetchSDKTests/KetchHeadlessLiveIntegrationTests.swift
+++ b/Tests/KetchSDKTests/KetchHeadlessLiveIntegrationTests.swift
@@ -9,9 +9,9 @@ import XCTest
 final class KetchHeadlessLiveIntegrationTests: XCTestCase {
     private var cancellables: Set<AnyCancellable> = []
 
-    override func setUp() {
-        super.setUp()
-        try? XCTSkipUnless(
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        try XCTSkipUnless(
             ProcessInfo.processInfo.environment["KETCH_INTEGRATION_TESTS"] == "1",
             "Set KETCH_INTEGRATION_TESTS=1 to run live CDN tests"
         )
@@ -86,11 +86,11 @@ final class KetchHeadlessLiveIntegrationTests: XCTestCase {
         KetchSDK.getRegion()
             .sink { completion in
                 if case .failure(let error) = completion { XCTFail("static getRegion failed: \(error)") }
+                expectation.fulfill()
             } receiveValue: { region in
                 XCTAssertFalse(region?.isEmpty ?? true, "Expected a non-empty region code from live GeoIP")
             }
             .store(in: &cancellables)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 5) { expectation.fulfill() }
         wait(for: [expectation], timeout: 45)
     }
 
@@ -104,11 +104,11 @@ final class KetchHeadlessLiveIntegrationTests: XCTestCase {
         KetchSDK.getJurisdiction(request: request)
             .sink { completion in
                 if case .failure(let error) = completion { XCTFail("static getJurisdiction failed: \(error)") }
+                expectation.fulfill()
             } receiveValue: { jurisdiction in
                 XCTAssertFalse(jurisdiction?.isEmpty ?? true, "Expected a non-empty jurisdiction code from live config")
             }
             .store(in: &cancellables)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 5) { expectation.fulfill() }
         wait(for: [expectation], timeout: 45)
     }
 

--- a/Tests/KetchSDKTests/KetchHeadlessLiveIntegrationTests.swift
+++ b/Tests/KetchSDKTests/KetchHeadlessLiveIntegrationTests.swift
@@ -1,0 +1,147 @@
+import Combine
+import XCTest
+@testable import KetchSDK
+
+/// Live CDN round-trip for the ported getRegion/getJurisdiction/trigger surface (sandbox org).
+///
+/// Run with network enabled:
+/// `KETCH_INTEGRATION_TESTS=1 xcodebuild -scheme KetchSDK -destination 'platform=iOS Simulator,name=iPhone 17' test -only-testing:KetchSDKTests/KetchHeadlessLiveIntegrationTests`
+final class KetchHeadlessLiveIntegrationTests: XCTestCase {
+    private var cancellables: Set<AnyCancellable> = []
+
+    override func setUp() {
+        super.setUp()
+        try? XCTSkipUnless(
+            ProcessInfo.processInfo.environment["KETCH_INTEGRATION_TESTS"] == "1",
+            "Set KETCH_INTEGRATION_TESTS=1 to run live CDN tests"
+        )
+        cancellables = []
+    }
+
+    override func tearDown() {
+        cancellables.removeAll()
+        super.tearDown()
+    }
+
+    private func makeKetch() -> Ketch {
+        Ketch(
+            organizationCode: HeadlessIntegrationSupport.orgCode,
+            propertyCode: HeadlessIntegrationSupport.propertyCode,
+            environmentCode: HeadlessIntegrationSupport.environmentCode,
+            identities: []
+        )
+    }
+
+    func testGetRegion_liveCDN_returnsRealValue() {
+        let ketch = makeKetch()
+        let expectation = expectation(description: "getRegion")
+        ketch.getRegion { result in
+            switch result {
+            case .success(let region):
+                XCTAssertFalse(region?.isEmpty ?? true, "Expected a non-empty region code from live GeoIP")
+            case .failure(let error):
+                XCTFail("getRegion failed: \(error)")
+            }
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 45)
+    }
+
+    func testGetRegion_liveCDN_secondCallServedFromCache() {
+        let ketch = makeKetch()
+        let first = expectation(description: "first getRegion")
+        var firstRegion: String?
+        ketch.getRegion { result in
+            firstRegion = try? result.get()
+            first.fulfill()
+        }
+        wait(for: [first], timeout: 45)
+
+        // A second call immediately after should return the same cached value without erroring.
+        let second = expectation(description: "second getRegion")
+        ketch.getRegion { result in
+            XCTAssertEqual(try? result.get(), firstRegion)
+            second.fulfill()
+        }
+        wait(for: [second], timeout: 5)
+    }
+
+    func testGetJurisdiction_liveCDN_returnsRealValue() {
+        let ketch = makeKetch()
+        let expectation = expectation(description: "getJurisdiction")
+        ketch.getJurisdiction { result in
+            switch result {
+            case .success(let jurisdiction):
+                XCTAssertFalse(jurisdiction?.isEmpty ?? true, "Expected a non-empty jurisdiction code from live config")
+            case .failure(let error):
+                XCTFail("getJurisdiction failed: \(error)")
+            }
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 45)
+    }
+
+    func testStaticGetRegion_liveCDN_returnsRealValue() {
+        let expectation = expectation(description: "static getRegion")
+        KetchSDK.getRegion()
+            .sink { completion in
+                if case .failure(let error) = completion { XCTFail("static getRegion failed: \(error)") }
+            } receiveValue: { region in
+                XCTAssertFalse(region?.isEmpty ?? true, "Expected a non-empty region code from live GeoIP")
+            }
+            .store(in: &cancellables)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5) { expectation.fulfill() }
+        wait(for: [expectation], timeout: 45)
+    }
+
+    func testStaticGetJurisdiction_liveCDN_returnsRealValue() {
+        let expectation = expectation(description: "static getJurisdiction")
+        let request = KetchSDK.FullConfigurationRequest(
+            organizationCode: HeadlessIntegrationSupport.orgCode,
+            propertyCode: HeadlessIntegrationSupport.propertyCode,
+            environmentCode: HeadlessIntegrationSupport.environmentCode
+        )
+        KetchSDK.getJurisdiction(request: request)
+            .sink { completion in
+                if case .failure(let error) = completion { XCTFail("static getJurisdiction failed: \(error)") }
+            } receiveValue: { jurisdiction in
+                XCTAssertFalse(jurisdiction?.isEmpty ?? true, "Expected a non-empty jurisdiction code from live config")
+            }
+            .store(in: &cancellables)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5) { expectation.fulfill() }
+        wait(for: [expectation], timeout: 45)
+    }
+
+    /// Drives a real WKWebView against the live CDN. Confirms the cold path (called before config
+    /// loads, deferred) and the warm path (called after config loads, fires immediately) both
+    /// return `true` and neither crashes nor throws at the Swift/JS bridge. This does not assert an
+    /// experience actually appeared — that requires a backend onFunction rule for the given
+    /// function name configured on the sandbox org, which is outside this test's control.
+    func testTrigger_liveCDN_coldThenWarmPath() {
+        let ketch = makeKetch()
+        let ketchUI = KetchUI(ketch: ketch)
+
+        // Cold path: fired immediately after init, before the tag has had a chance to boot.
+        let coldAccepted = ketchUI.trigger(triggerName: .custom, functionName: "smokeTestColdTrigger")
+        XCTAssertTrue(coldAccepted, "Cold trigger() should be accepted (deferred) even before config loads")
+
+        let configLoaded = expectation(description: "configuration loaded")
+        ketchUI.$configuration
+            .compactMap { $0 }
+            .first()
+            .sink { _ in configLoaded.fulfill() }
+            .store(in: &cancellables)
+        wait(for: [configLoaded], timeout: 45)
+
+        // Warm path: config is now loaded, so this should fire immediately via evaluateJavaScript.
+        let warmAccepted = ketchUI.trigger(triggerName: .custom, functionName: "smokeTestWarmTrigger")
+        XCTAssertTrue(warmAccepted, "Warm trigger() should be accepted once config has loaded")
+    }
+
+    func testTrigger_liveCDN_rejectsInvalidFunctionName() {
+        let ketch = makeKetch()
+        let ketchUI = KetchUI(ketch: ketch)
+        XCTAssertFalse(ketchUI.trigger(triggerName: .custom, functionName: ""))
+        XCTAssertFalse(ketchUI.trigger(triggerName: .custom, functionName: "has space"))
+    }
+}

--- a/Tests/KetchSDKTests/LocationRegionCodeTests.swift
+++ b/Tests/KetchSDKTests/LocationRegionCodeTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+@testable import KetchSDK
+
+final class LocationRegionCodeTests: XCTestCase {
+    private func ipInfo(countryCode: String?, regionCode: String?) -> KetchSDK.IPInfo {
+        KetchSDK.IPInfo(
+            ip: nil,
+            hostname: nil,
+            continentCode: nil,
+            continentName: nil,
+            countryCode: countryCode,
+            countryName: nil,
+            regionCode: regionCode,
+            regionName: nil,
+            city: nil,
+            postalCode: nil,
+            timezone: nil
+        )
+    }
+
+    func testToRegionCode_countryAndRegion_combinesWithHyphen() {
+        XCTAssertEqual(ipInfo(countryCode: "US", regionCode: "CA").toRegionCode(), "US-CA")
+    }
+
+    func testToRegionCode_countryOnly() {
+        XCTAssertEqual(ipInfo(countryCode: "US", regionCode: nil).toRegionCode(), "US")
+    }
+
+    func testToRegionCode_countryOnly_blankRegion() {
+        XCTAssertEqual(ipInfo(countryCode: "US", regionCode: "").toRegionCode(), "US")
+    }
+
+    func testToRegionCode_regionOnly_whenCountryAbsent() {
+        XCTAssertEqual(ipInfo(countryCode: nil, regionCode: "CA").toRegionCode(), "CA")
+    }
+
+    func testToRegionCode_regionOnly_whenCountryBlank() {
+        XCTAssertEqual(ipInfo(countryCode: "", regionCode: "CA").toRegionCode(), "CA")
+    }
+
+    func testToRegionCode_bothAbsent_returnsNil() {
+        XCTAssertNil(ipInfo(countryCode: nil, regionCode: nil).toRegionCode())
+    }
+
+    func testToRegionCode_bothBlank_returnsNil() {
+        XCTAssertNil(ipInfo(countryCode: "", regionCode: "").toRegionCode())
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Code generated by shipbuilder init 1.21.3. DO NOT EDIT. -->

## Description of this change

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

Test coverage for the headless API client and consent paths: `HeadlessApiClientTests`, `HeadlessConsentTests`, `FullConfigurationRequestTests`, `LocationRegionCodeTests`, `HeadlessCdnIntegrationTests`, `HeadlessIntegrationSupport`, `KetchHeadlessLiveIntegrationTests`.

Pulled forward from directly after #81 in the original PR's diff order to here, because `HeadlessCdnIntegrationTests`/`KetchHeadlessLiveIntegrationTests` call `Ketch.getRegion`/`getJurisdiction` (#83) and `KetchUI.trigger` (#85) — none of which exist yet at #81.

Part 8/9 of the split of #76.

Also adds coverage for the language-tag and config-request fixes in #81: preserving script/region subtags, and synthesizing a device-locale language when environment and jurisdiction are set but language isn't.

Also fixes two issues Bugbot found on this branch: the live-CDN skip guard used `try?` on `XCTSkipUnless`, which swallowed the skip entirely, so those suites ran against the network by default; and two tests fulfilled their expectation on a fixed timer instead of the actual completion, so a slow response could let the assertion never run. Also rewrites `HeadlessConsentTests`'s stubs from a custom `URLSession` to a custom `ApiClient`, since the consent/rights POSTs now go through the injected client instead of a raw session.

## Why is this change being made?

- [x] Chore (non-functional changes)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

`xcodebuild -scheme KetchSDK -destination 'generic/platform=iOS Simulator' build` — succeeded (build only). `HeadlessCdnIntegrationTests` and `KetchHeadlessLiveIntegrationTests` hit the live Ketch CDN and are excluded from the run-time suite, not just this gate — they're exercised separately, outside CI.

## Related issues

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Refs #76 — layer 8 of 9 in the split of #76.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.