### PR TITLE
feat: add privacy string accessors, and document the new surface

### DIFF
--- a/Examples/KetchSDKSample/KetchSDK/ContentView.swift
+++ b/Examples/KetchSDKSample/KetchSDK/ContentView.swift
@@ -66,6 +66,9 @@ struct ContentView: View {
     @State private var selectedTabs: Set<KetchUI.ExperienceOption.PreferencesTab> = Set([.overviewTab, .consentsTab, .subscriptionsTab, .rightsTab])
     @State private var selectedTab = KetchUI.ExperienceOption.PreferencesTab.overviewTab
 
+    @State private var headlessJurisdiction = ""
+    @State private var triggerResult = ""
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading) {
@@ -118,30 +121,26 @@ struct ContentView: View {
                     .font(.footnote)
                     .foregroundStyle(Color.gray)
 
-                HStack {
+                LazyVGrid(columns: [GridItem(.adaptive(minimum: 90), spacing: 12)], alignment: .leading, spacing: 12) {
                     Button("Reload") {
                         ketchUI.reload(with: makeParameters)
                     }
-
-                    Spacer()
 
                     Button("Consent") {
                         showConsent()
                     }
 
-                    Spacer()
-
                     Button("Preferences") {
                         showPreferences()
                     }
 
-                    Spacer()
+                    Button("Trigger") {
+                        triggerFunctionTapped()
+                    }
 
                     Button("Privacy Strings") {
                         showPrivacyStrings()
                     }
-
-                    Spacer()
 
                     Button("Apply CSS") {
                         applyCSS()
@@ -149,8 +148,6 @@ struct ContentView: View {
 
                     #if canImport(AppTrackingTransparency)
                     if #available(iOS 14, *) {
-                        Spacer()
-
                         Button("Request ATT") {
                             requestATT()
                         }
@@ -158,6 +155,27 @@ struct ContentView: View {
                     #endif
                 }
                 .padding(.vertical)
+
+                if !triggerResult.isEmpty {
+                    infoRow("Trigger Result", triggerResult)
+                }
+
+                Text("Headless SDK")
+                    .font(.title2)
+
+                Text("Calls the pre-WebView headless API directly")
+                    .font(.footnote)
+                    .foregroundStyle(Color.gray)
+                    .padding(.bottom, 8)
+
+                Button("Get Jurisdiction") {
+                    getJurisdictionTapped()
+                }
+                .padding(.bottom, 8)
+
+                if !headlessJurisdiction.isEmpty {
+                    infoRow("Headless Jurisdiction", headlessJurisdiction)
+                }
 
                 Spacer()
             }
@@ -262,6 +280,30 @@ struct ContentView: View {
         parameters.append(.css("#ketch-banner-button-primary { display: none !important; }"))
         parameters.append(.forceExperience(.consent))
         ketchUI.reload(with: parameters)
+    }
+
+    /// Calls the headless `getJurisdiction()` API directly (no WebView needed).
+    private func getJurisdictionTapped() {
+        print("[KetchSample] getJurisdiction() called")
+        ketchUI.ketch.getJurisdiction { result in
+            DispatchQueue.main.async {
+                switch result {
+                case .success(let jurisdiction):
+                    headlessJurisdiction = jurisdiction ?? "?"
+                case .failure(let error):
+                    headlessJurisdiction = "error: \(error)"
+                }
+                print("[KetchSample] getJurisdiction() -> \(headlessJurisdiction)")
+            }
+        }
+    }
+
+    /// Fires an onFunction rule trigger by custom function name. Configure a matching backend
+    /// rule on the sandbox org for "demoFunction" to see an experience actually appear.
+    private func triggerFunctionTapped() {
+        let accepted = ketchUI.trigger(triggerName: .custom, functionName: "demoFunction")
+        triggerResult = "demoFunction accepted=\(accepted)"
+        print("[KetchSample] trigger('demoFunction') -> accepted=\(accepted)")
     }
 
     /// Reads the current ATT status from the SDK + the previously stored status from native

--- a/README.md
+++ b/README.md
@@ -67,11 +67,16 @@ private func setupKetch(advertisingIdentifier: UUID) {
           Ketch.Identity(key: "aaid", value: "00000000-0000-0000-0000-000000000000"),
           Ketch.Identity(key: "email", value: "user@mywebsite.com"),
           Ketch.Identity(key: "account_id", value: "1234")
-      ]
+      ],
+      dataCenter: .us
    )
    self.ketch = ketch
 }
 ```
+
+`dataCenter` selects the server, and therefore which build of the Ketch tag is
+used: `.us` and `.eu` are production, `.uat` is the UAT environment. Defaults to
+`.us`.
 
 ### Step 2. Instantiate the KetchUI object:
 
@@ -189,6 +194,9 @@ extension KetchUI {
         /// Upper bound of age range for age band legal basis resolution
         case ageUpper(UInt)
 
+        /// Serve specific tag resources from another host
+        case webResourceUrlOverrides([String: String])
+
         public enum ExperienceToShow: String {
             case consent, preferences
         }
@@ -225,7 +233,9 @@ ketchUI.reload(with: params)
 ```swift
 public protocol KetchEventListener: AnyObject {
     func onShow()
-    func onDismiss()
+    func onWillShowExperience(type: KetchSDK.WillShowExperienceType)
+    func onHasShownExperience()
+    func onDismiss(status: KetchSDK.HideExperienceStatus)
     func onEnvironmentUpdated(environment: String?)
     func onRegionInfoUpdated(regionInfo: String?)
     func onJurisdictionUpdated(jurisdiction: String?)
@@ -235,6 +245,7 @@ public protocol KetchEventListener: AnyObject {
     func onCCPAUpdated(ccpaString: String?)
     func onTCFUpdated(tcfString: String?)
     func onGPPUpdated(gppString: String?)
+    func onNativeStoragePut(key: String, value: String)
 }
 ```
 
@@ -243,6 +254,44 @@ public protocol KetchEventListener: AnyObject {
 ```swift
 ketchUI.eventListener = #{myEventListener}#
 ```
+
+### Rule Triggers
+
+Fire an `onFunction` rule. If a matching backend rule shows an experience, it is
+presented automatically.
+
+```swift
+ketchUI.trigger(triggerName: .custom, functionName: "managePrivacy")
+```
+
+Returns `false` if the function name is invalid or an experience is already
+showing. Calls made before the tag finishes loading are queued and fired once it
+is ready.
+
+### Reading Values
+
+Resolved region and jurisdiction, preferring anything you set explicitly over a
+network lookup:
+
+```swift
+ketch.getRegion { result in /* String? */ }
+ketch.getJurisdiction { result in /* String? */ }
+```
+
+IAB privacy strings, as written to native storage by the tag:
+
+```swift
+ketch.getTCFTCString()
+ketch.getUSPrivacyString()
+ketch.getGPPHDRGppString()
+ketch.getSavedString(key: Ketch.PrivacyStringKey.tcfTCString)
+```
+
+`Ketch` and `KetchSDK` also expose headless HTTP methods —
+`getBootstrapConfiguration`, `getFullConfiguration`, `getConsent`, `setConsent`,
+`invokeRight`, `getSubscriptions`, `setSubscriptions`, `getPreferenceQRUrl` —
+for consent operations that need no WebView. Instance methods take completion
+handlers; the `KetchSDK` statics return Combine publishers.
 
 ### Sample app
 

--- a/Sources/KetchSDK/Core/Ketch.swift
+++ b/Sources/KetchSDK/Core/Ketch.swift
@@ -650,3 +650,35 @@ extension Ketch {
         nativeStorage.value(forKey: PREFERENCE_VERSION) as? Int
     }
 }
+
+// MARK: - Privacy strings
+
+extension Ketch {
+    /// Storage keys the ketch tag writes IAB privacy strings to. Names match the IAB
+    /// specifications and the keys used by the Android and Flutter SDKs.
+    public enum PrivacyStringKey {
+        public static let tcfTCString = "IABTCF_TCString"
+        public static let usPrivacyString = "IABUSPrivacy_String"
+        public static let gppHDRGppString = "IABGPP_HDR_GppString"
+    }
+
+    /// Read a value the tag wrote to native storage.
+    public func getSavedString(key: String) -> String {
+        nativeStorage.read(key: key)
+    }
+
+    /// Retrieve the IABTCF_TCString value written by the tag.
+    public func getTCFTCString() -> String {
+        getSavedString(key: PrivacyStringKey.tcfTCString)
+    }
+
+    /// Retrieve the IABUSPrivacy_String value written by the tag.
+    public func getUSPrivacyString() -> String {
+        getSavedString(key: PrivacyStringKey.usPrivacyString)
+    }
+
+    /// Retrieve the IABGPP_HDR_GppString value written by the tag.
+    public func getGPPHDRGppString() -> String {
+        getSavedString(key: PrivacyStringKey.gppHDRGppString)
+    }
+}

--- a/Tests/KetchSDKTests/PrivacyStringKeyTests.swift
+++ b/Tests/KetchSDKTests/PrivacyStringKeyTests.swift
@@ -1,0 +1,17 @@
+//
+//  PrivacyStringKeyTests.swift
+//  KetchSDKTests
+//
+
+import XCTest
+@testable import KetchSDK
+
+/// The tag writes these exact keys, and the Android and Flutter SDKs read the same
+/// names. A rename here silently breaks every consumer reading the strings back.
+final class PrivacyStringKeyTests: XCTestCase {
+    func testKeysMatchIABSpecification() {
+        XCTAssertEqual(Ketch.PrivacyStringKey.tcfTCString, "IABTCF_TCString")
+        XCTAssertEqual(Ketch.PrivacyStringKey.usPrivacyString, "IABUSPrivacy_String")
+        XCTAssertEqual(Ketch.PrivacyStringKey.gppHDRGppString, "IABGPP_HDR_GppString")
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Code generated by shipbuilder init 1.21.3. DO NOT EDIT. -->

## Description of this change

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

Adds privacy string accessors (`PrivacyStringKey`, `getSavedString`, `getTCFTCString`, `getUSPrivacyString`, `getGPPHDRGppString`) and documents the new surface in `README.md`. Topmost layer touching `Ketch.swift`; also updates the sample app (`ContentView.swift`) and adds `PrivacyStringKeyTests.swift`.

Top of the stack. Union invariant verified: `git diff --exit-code <this-branch> origin/ethanpschoen/feat/headless-api` → empty, exit 0 — every hunk from the original PR lands exactly once, unmodified, across the 9-layer stack. Structural checks: 0 merge commits, 9 commits, all GPG-signed, all conventional. Total diff matches the original PR exactly: +3022/−324 across 31 files.

The stack's execution order deviates from the original PR's diff order in three places (#82, #83, #86) — each carries its own note explaining why. No hunks were re-split or re-derived; only the order in which the same 9 layers were built and committed changed.

Part 9/9 of the split of #76.

## Why is this change being made?

- [ ] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

`xcodebuild -scheme KetchSDK -destination 'generic/platform=iOS Simulator' build` — succeeded. Full test suite (excluding the two live-CDN tests from #86): 71/71 passed.

## Related issues

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Refs #76 — layer 9 of 9 (top) in the split of #76.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.