### PR TITLE
feat: policy/trigger parity and privacy string accessors

### DIFF
--- a/Examples/KetchSDKSample/KetchSDK/ContentView.swift
+++ b/Examples/KetchSDKSample/KetchSDK/ContentView.swift
@@ -66,6 +66,9 @@ struct ContentView: View {
     @State private var selectedTabs: Set<KetchUI.ExperienceOption.PreferencesTab> = Set([.overviewTab, .consentsTab, .subscriptionsTab, .rightsTab])
     @State private var selectedTab = KetchUI.ExperienceOption.PreferencesTab.overviewTab
 
+    @State private var headlessJurisdiction = ""
+    @State private var triggerResult = ""
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading) {
@@ -118,30 +121,26 @@ struct ContentView: View {
                     .font(.footnote)
                     .foregroundStyle(Color.gray)
 
-                HStack {
+                LazyVGrid(columns: [GridItem(.adaptive(minimum: 90), spacing: 12)], alignment: .leading, spacing: 12) {
                     Button("Reload") {
                         ketchUI.reload(with: makeParameters)
                     }
-
-                    Spacer()
 
                     Button("Consent") {
                         showConsent()
                     }
 
-                    Spacer()
-
                     Button("Preferences") {
                         showPreferences()
                     }
 
-                    Spacer()
+                    Button("Trigger") {
+                        triggerFunctionTapped()
+                    }
 
                     Button("Privacy Strings") {
                         showPrivacyStrings()
                     }
-
-                    Spacer()
 
                     Button("Apply CSS") {
                         applyCSS()
@@ -149,8 +148,6 @@ struct ContentView: View {
 
                     #if canImport(AppTrackingTransparency)
                     if #available(iOS 14, *) {
-                        Spacer()
-
                         Button("Request ATT") {
                             requestATT()
                         }
@@ -158,6 +155,27 @@ struct ContentView: View {
                     #endif
                 }
                 .padding(.vertical)
+
+                if !triggerResult.isEmpty {
+                    infoRow("Trigger Result", triggerResult)
+                }
+
+                Text("Headless SDK")
+                    .font(.title2)
+
+                Text("Calls the pre-WebView headless API directly")
+                    .font(.footnote)
+                    .foregroundStyle(Color.gray)
+                    .padding(.bottom, 8)
+
+                Button("Get Jurisdiction") {
+                    getJurisdictionTapped()
+                }
+                .padding(.bottom, 8)
+
+                if !headlessJurisdiction.isEmpty {
+                    infoRow("Headless Jurisdiction", headlessJurisdiction)
+                }
 
                 Spacer()
             }
@@ -262,6 +280,30 @@ struct ContentView: View {
         parameters.append(.css("#ketch-banner-button-primary { display: none !important; }"))
         parameters.append(.forceExperience(.consent))
         ketchUI.reload(with: parameters)
+    }
+
+    /// Calls the headless `getJurisdiction()` API directly (no WebView needed).
+    private func getJurisdictionTapped() {
+        print("[KetchSample] getJurisdiction() called")
+        ketchUI.ketch.getJurisdiction { result in
+            DispatchQueue.main.async {
+                switch result {
+                case .success(let jurisdiction):
+                    headlessJurisdiction = jurisdiction ?? "?"
+                case .failure(let error):
+                    headlessJurisdiction = "error: \(error)"
+                }
+                print("[KetchSample] getJurisdiction() -> \(headlessJurisdiction)")
+            }
+        }
+    }
+
+    /// Fires an onFunction rule trigger by custom function name. Configure a matching backend
+    /// rule on the sandbox org for "demoFunction" to see an experience actually appear.
+    private func triggerFunctionTapped() {
+        let accepted = ketchUI.trigger(triggerName: .custom, functionName: "demoFunction")
+        triggerResult = "demoFunction accepted=\(accepted)"
+        print("[KetchSample] trigger('demoFunction') -> accepted=\(accepted)")
     }
 
     /// Reads the current ATT status from the SDK + the previously stored status from native

--- a/README.md
+++ b/README.md
@@ -67,11 +67,16 @@ private func setupKetch(advertisingIdentifier: UUID) {
           Ketch.Identity(key: "aaid", value: "00000000-0000-0000-0000-000000000000"),
           Ketch.Identity(key: "email", value: "user@mywebsite.com"),
           Ketch.Identity(key: "account_id", value: "1234")
-      ]
+      ],
+      dataCenter: .us
    )
    self.ketch = ketch
 }
 ```
+
+`dataCenter` selects the server, and therefore which build of the Ketch tag is
+used: `.us` and `.eu` are production, `.uat` is the UAT environment. Defaults to
+`.us`.
 
 ### Step 2. Instantiate the KetchUI object:
 
@@ -189,6 +194,9 @@ extension KetchUI {
         /// Upper bound of age range for age band legal basis resolution
         case ageUpper(UInt)
 
+        /// Serve specific tag resources from another host
+        case webResourceUrlOverrides([String: String])
+
         public enum ExperienceToShow: String {
             case consent, preferences
         }
@@ -225,7 +233,9 @@ ketchUI.reload(with: params)
 ```swift
 public protocol KetchEventListener: AnyObject {
     func onShow()
-    func onDismiss()
+    func onWillShowExperience(type: KetchSDK.WillShowExperienceType)
+    func onHasShownExperience()
+    func onDismiss(status: KetchSDK.HideExperienceStatus)
     func onEnvironmentUpdated(environment: String?)
     func onRegionInfoUpdated(regionInfo: String?)
     func onJurisdictionUpdated(jurisdiction: String?)
@@ -235,6 +245,7 @@ public protocol KetchEventListener: AnyObject {
     func onCCPAUpdated(ccpaString: String?)
     func onTCFUpdated(tcfString: String?)
     func onGPPUpdated(gppString: String?)
+    func onNativeStoragePut(key: String, value: String)
 }
 ```
 
@@ -243,6 +254,44 @@ public protocol KetchEventListener: AnyObject {
 ```swift
 ketchUI.eventListener = #{myEventListener}#
 ```
+
+### Rule Triggers
+
+Fire an `onFunction` rule. If a matching backend rule shows an experience, it is
+presented automatically.
+
+```swift
+ketchUI.trigger(triggerName: .custom, functionName: "managePrivacy")
+```
+
+Returns `false` if the function name is invalid or an experience is already
+showing. Calls made before the tag finishes loading are queued and fired once it
+is ready.
+
+### Reading Values
+
+Resolved region and jurisdiction, preferring anything you set explicitly over a
+network lookup:
+
+```swift
+ketch.getRegion { result in /* String? */ }
+ketch.getJurisdiction { result in /* String? */ }
+```
+
+IAB privacy strings, as written to native storage by the tag:
+
+```swift
+ketch.getTCFTCString()
+ketch.getUSPrivacyString()
+ketch.getGPPHDRGppString()
+ketch.getSavedString(key: Ketch.PrivacyStringKey.tcfTCString)
+```
+
+`Ketch` and `KetchSDK` also expose headless HTTP methods —
+`getBootstrapConfiguration`, `getFullConfiguration`, `getConsent`, `setConsent`,
+`invokeRight`, `getSubscriptions`, `setSubscriptions`, `getPreferenceQRUrl` —
+for consent operations that need no WebView. Instance methods take completion
+handlers; the `KetchSDK` statics return Combine publishers.
 
 ### Sample app
 

--- a/Sources/KetchSDK/Core/Ketch.swift
+++ b/Sources/KetchSDK/Core/Ketch.swift
@@ -650,3 +650,35 @@ extension Ketch {
         nativeStorage.value(forKey: PREFERENCE_VERSION) as? Int
     }
 }
+
+// MARK: - Privacy strings
+
+extension Ketch {
+    /// Storage keys the ketch tag writes IAB privacy strings to. Names match the IAB
+    /// specifications and the keys used by the Android and Flutter SDKs.
+    public enum PrivacyStringKey {
+        public static let tcfTCString = "IABTCF_TCString"
+        public static let usPrivacyString = "IABUSPrivacy_String"
+        public static let gppHDRGppString = "IABGPP_HDR_GppString"
+    }
+
+    /// Read a value the tag wrote to native storage.
+    public func getSavedString(key: String) -> String {
+        nativeStorage.read(key: key)
+    }
+
+    /// Retrieve the IABTCF_TCString value written by the tag.
+    public func getTCFTCString() -> String {
+        getSavedString(key: PrivacyStringKey.tcfTCString)
+    }
+
+    /// Retrieve the IABUSPrivacy_String value written by the tag.
+    public func getUSPrivacyString() -> String {
+        getSavedString(key: PrivacyStringKey.usPrivacyString)
+    }
+
+    /// Retrieve the IABGPP_HDR_GppString value written by the tag.
+    public func getGPPHDRGppString() -> String {
+        getSavedString(key: PrivacyStringKey.gppHDRGppString)
+    }
+}

--- a/Sources/KetchSDK/Core/Ketch.swift
+++ b/Sources/KetchSDK/Core/Ketch.swift
@@ -613,6 +613,22 @@ extension Ketch {
     }
 }
 
+// MARK: - Internal interface for plugin lifecycle events
+extension Ketch {
+    func notifyWillShowExperience() {
+        plugins.forEach { plugin in
+            plugin.willShowExperience()
+        }
+    }
+
+    func notifyExperienceHidden(status: KetchSDK.HideExperienceStatus) {
+        let reason = ExperienceHiddenReason(status: status)
+        plugins.forEach { plugin in
+            plugin.experienceHidden(reason: reason)
+        }
+    }
+}
+
 private let CONSENT_VERSION = "consent_version"
 private let PREFERENCE_VERSION = "preference_version"
 

--- a/Sources/KetchSDK/Core/PolicyProtocol.swift
+++ b/Sources/KetchSDK/Core/PolicyProtocol.swift
@@ -42,6 +42,21 @@ public enum ExperienceHiddenReason: String {
   case invokeRight
   case close
   case willNotShow
+  case closeWithoutSettingConsent
+  case setSubscriptions
+  case none
+
+  init(status: KetchSDK.HideExperienceStatus) {
+    switch status {
+    case .SetConsent: self = .setConsent
+    case .InvokeRight: self = .invokeRight
+    case .Close: self = .close
+    case .WillNotShow: self = .willNotShow
+    case .CloseWithoutSettingConsent: self = .closeWithoutSettingConsent
+    case .SetSubscriptions: self = .setSubscriptions
+    case .None: self = .none
+    }
+  }
 }
 
 public enum PolicyPluginError: Error {

--- a/Sources/KetchSDK/UI/KetchUI.swift
+++ b/Sources/KetchSDK/UI/KetchUI.swift
@@ -33,6 +33,15 @@ public final class KetchUI: ObservableObject {
     private var experienceToShow: KetchUI.WebPresentationItem.Event.Content?
     private var preloadedPresentationItem: WebPresentationItem?
 
+    // Deferred trigger() call, fired once a cold-booted WebView's tag finishes loading
+    private var pendingTrigger: PendingTrigger?
+
+    private struct PendingTrigger {
+        let triggerName: TriggerName
+        let functionName: String
+        let optionsJson: String
+    }
+
     /// Instantiation of UI dialogs
     /// - Parameter ketch: Instance of Ketch that will provide request and storage services,
     /// - Parameter options: default options
@@ -102,9 +111,18 @@ public final class KetchUI: ObservableObject {
             
         case .configurationLoaded(let configuration):
             self.ketch.configuration = configuration
-            
+
             isConfigLoaded = true
-            
+
+            if let pending = pendingTrigger {
+                pendingTrigger = nil
+                preloadedPresentationItem?.trigger(
+                    triggerName: pending.triggerName.rawValue,
+                    functionName: pending.functionName,
+                    optionsJson: pending.optionsJson
+                )
+            }
+
             if experienceToShow != nil {
                 showExperience()
                 self.experienceToShow = nil
@@ -212,6 +230,55 @@ extension KetchUI {
     
     public func closeExperience() {
         webPresentationItem = nil
+    }
+
+    /// Fires a custom-function (`onFunction`) rule trigger. If a matching backend rule shows an
+    /// experience, it is displayed automatically.
+    ///
+    /// - Parameters:
+    ///   - triggerName: the trigger name; `.custom` is the only supported value today
+    ///   - functionName: the custom function name configured on the backend rule
+    ///   - options: optional key/value trigger arguments
+    /// - Returns: `false` if `functionName` is invalid, or an experience is already showing.
+    @discardableResult
+    public func trigger(
+        triggerName: TriggerName,
+        functionName: String,
+        options: [String: Any] = [:]
+    ) -> Bool {
+        guard Self.isValidTriggerFunctionName(functionName) else {
+            KetchLogger.log.debug("[Ketch] trigger rejected: functionName must be non-blank and contain only letters, digits, '_', '-', or '.'")
+            return false
+        }
+        guard webPresentationItem == nil else {
+            KetchLogger.log.debug("Not triggering '\(functionName)' as an experience is already being shown")
+            return false
+        }
+
+        let optionsJson = Self.jsonString(from: options)
+
+        if isConfigLoaded {
+            pendingTrigger = nil
+            preloadedPresentationItem?.trigger(triggerName: triggerName.rawValue, functionName: functionName, optionsJson: optionsJson)
+        } else {
+            pendingTrigger = PendingTrigger(triggerName: triggerName, functionName: functionName, optionsJson: optionsJson)
+        }
+        return true
+    }
+
+    /// Mirrors ketch-tag's function-name validation: non-blank, and only letters, digits, '_', '-', or '.'.
+    static func isValidTriggerFunctionName(_ functionName: String) -> Bool {
+        !functionName.isEmpty
+            && functionName.range(of: "^[A-Za-z0-9_.-]+$", options: .regularExpression) != nil
+    }
+
+    private static func jsonString(from options: [String: Any]) -> String {
+        guard let data = try? JSONSerialization.data(withJSONObject: options),
+              let json = String(data: data, encoding: .utf8)
+        else {
+            return "{}"
+        }
+        return json
     }
 }
 

--- a/Sources/KetchSDK/UI/KetchUI.swift
+++ b/Sources/KetchSDK/UI/KetchUI.swift
@@ -29,14 +29,20 @@ public final class KetchUI: ObservableObject {
     private(set) public var ketch: Ketch
     private var subscriptions = Set<AnyCancellable>()
     private var options = [ExperienceOption]()
-    private var isConfigLoaded = false
+    // Whether the *currently loaded* page's tag has finished booting (emitted .configurationLoaded).
+    // Distinct from "an experience is pending" (experienceToShow) or "queued" (pendingTrigger) --
+    // those track what should happen once the tag boots, this tracks whether it has.
+    // internal, not private: exercised directly by TriggerValidationTests via @testable import,
+    // since there is no test seam for driving the WebPresentationItem bridge from outside.
+    var isTagBooted = false
     private var experienceToShow: KetchUI.WebPresentationItem.Event.Content?
     private var preloadedPresentationItem: WebPresentationItem?
 
-    // Deferred trigger() call, fired once a cold-booted WebView's tag finishes loading
-    private var pendingTrigger: PendingTrigger?
+    // Deferred trigger() call, fired once a cold-booted WebView's tag finishes loading.
+    // internal, not private: see isTagBooted's comment above.
+    var pendingTrigger: PendingTrigger?
 
-    private struct PendingTrigger {
+    struct PendingTrigger {
         let triggerName: TriggerName
         let functionName: String
         let optionsJson: String
@@ -76,8 +82,16 @@ public final class KetchUI: ObservableObject {
     }
     
     private func preloadWebExperience() {
+        resetBridgeState()
         preloadedPresentationItem = webExperience(onEvent: handle)
         preloadedPresentationItem?.reload(options: experienceOptionsWithDataCenter(options))
+    }
+
+    // Single choke point for "a new page is about to load". Resets the state that describes the
+    // *current* page, but deliberately leaves pendingTrigger alone -- a trigger() queued before a
+    // reload should still fire once the new page's tag boots, not be discarded by the reload.
+    private func resetBridgeState() {
+        isTagBooted = false
     }
 
     private func experienceOptionsWithDataCenter(_ options: [ExperienceOption]) -> [ExperienceOption] {
@@ -89,7 +103,8 @@ public final class KetchUI: ObservableObject {
         return result
     }
     
-    private func handle(webPresentationEvent: WebPresentationItem.Event) {
+    // internal, not private: see isTagBooted's comment above.
+    func handle(webPresentationEvent: WebPresentationItem.Event) {
         switch webPresentationEvent {
         case .onClose(let status):
             didCloseExperience(status: status)
@@ -112,7 +127,7 @@ public final class KetchUI: ObservableObject {
         case .configurationLoaded(let configuration):
             self.ketch.configuration = configuration
 
-            isConfigLoaded = true
+            isTagBooted = true
 
             if let pending = pendingTrigger {
                 pendingTrigger = nil
@@ -126,7 +141,6 @@ public final class KetchUI: ObservableObject {
             if experienceToShow != nil {
                 showExperience()
                 self.experienceToShow = nil
-                isConfigLoaded = false
                 eventListener?.onShow()
             }
 
@@ -168,7 +182,7 @@ public final class KetchUI: ObservableObject {
     }
 
     private func presentExperience(_ content: WebPresentationItem.Event.Content) {
-        if isConfigLoaded {
+        if isTagBooted {
             // .show and .willShowExperience both fire for the same experience on the warm path;
             // only the first to arrive should actually dispatch showExperience()/onShow().
             guard webPresentationItem == nil else { return }
@@ -198,9 +212,10 @@ public final class KetchUI: ObservableObject {
 // MARK: - Direct trigger of dialog item presentation
 extension KetchUI {
     public func reload(with options: [ExperienceOption] = []) {
+        resetBridgeState()
         preloadedPresentationItem?.webView?.configuration.userContentController.removeAllScriptMessageHandlers()
         preloadedPresentationItem = webExperience(onEvent: handle)
-        
+
         // merge options, override existing if needed
         var newOptions = self.options
         options.forEach { option in
@@ -257,7 +272,7 @@ extension KetchUI {
 
         let optionsJson = Self.jsonString(from: options)
 
-        if isConfigLoaded {
+        if isTagBooted {
             pendingTrigger = nil
             preloadedPresentationItem?.trigger(triggerName: triggerName.rawValue, functionName: functionName, optionsJson: optionsJson)
         } else {

--- a/Sources/KetchSDK/UI/KetchUI.swift
+++ b/Sources/KetchSDK/UI/KetchUI.swift
@@ -86,15 +86,13 @@ public final class KetchUI: ObservableObject {
             didCloseExperience(status: status)
             
         case .show(let content):
-            if isConfigLoaded {
-                self.showExperience()
-                eventListener?.onShow()
-            } else {
-                experienceToShow = content
-            }
-            
+            presentExperience(content)
+
         case .willShowExperience(let type):
             eventListener?.onWillShowExperience(type: type)
+            ketch.notifyWillShowExperience()
+            // The only show signal guaranteed to fire for every experience path.
+            presentExperience(type == .ConsentExperience ? .consent : .preference)
             
         case .hasShownExperience:
             eventListener?.onHasShownExperience()
@@ -148,6 +146,16 @@ public final class KetchUI: ObservableObject {
     private func didCloseExperience(status: KetchSDK.HideExperienceStatus) {
         webPresentationItem = nil
         eventListener?.onDismiss(status: status)
+        ketch.notifyExperienceHidden(status: status)
+    }
+
+    private func presentExperience(_ content: WebPresentationItem.Event.Content) {
+        if isConfigLoaded {
+            showExperience()
+            eventListener?.onShow()
+        } else {
+            experienceToShow = content
+        }
     }
     
     private var display: KetchSDK.Configuration.Experience.ContentDisplay {

--- a/Sources/KetchSDK/UI/KetchUI.swift
+++ b/Sources/KetchSDK/UI/KetchUI.swift
@@ -151,6 +151,9 @@ public final class KetchUI: ObservableObject {
 
     private func presentExperience(_ content: WebPresentationItem.Event.Content) {
         if isConfigLoaded {
+            // .show and .willShowExperience both fire for the same experience on the warm path;
+            // only the first to arrive should actually dispatch showExperience()/onShow().
+            guard webPresentationItem == nil else { return }
             showExperience()
             eventListener?.onShow()
         } else {

--- a/Sources/KetchSDK/UI/PresentationItem/PresentationItem.swift
+++ b/Sources/KetchSDK/UI/PresentationItem/PresentationItem.swift
@@ -319,9 +319,14 @@ extension KetchUI.WebPresentationItem {
     public func showPreferences() {
         webView?.evaluateJavaScript("ketch('showPreferences')")
     }
-    
+
     public func showConsent() {
         webView?.evaluateJavaScript("ketch('showConsent')")
+    }
+
+    /// Fires a custom-function (`onFunction`) rule trigger on an already-booted page.
+    func trigger(triggerName: String, functionName: String, optionsJson: String) {
+        webView?.evaluateJavaScript("ketch('trigger', '\(triggerName)', '\(functionName)', \(optionsJson))")
     }
 }
 

--- a/Sources/KetchSDK/UI/TriggerName.swift
+++ b/Sources/KetchSDK/UI/TriggerName.swift
@@ -1,0 +1,10 @@
+//
+//  TriggerName.swift
+//  KetchSDK
+//
+
+/// The trigger name for `KetchUI.trigger` — mirrors ketch-tag's `ketch('trigger', <triggerName>, ...)`
+/// call shape. `.custom` is the only supported value today.
+public enum TriggerName: String {
+    case custom
+}

--- a/Tests/KetchSDKTests/PolicyPluginDispatchTests.swift
+++ b/Tests/KetchSDKTests/PolicyPluginDispatchTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+@testable import KetchSDK
+
+final class PolicyPluginDispatchTests: XCTestCase {
+
+    func testWillShowExperienceReachesRegisteredPlugin() {
+        let ketch = Ketch(organizationCode: "acme", propertyCode: "prop", environmentCode: "production", identities: [])
+        let plugin = SpyPolicyPlugin()
+        ketch.add(plugin: plugin)
+
+        ketch.notifyWillShowExperience()
+
+        XCTAssertEqual(plugin.willShowExperienceCount, 1)
+    }
+
+    func testExperienceHiddenReachesRegisteredPluginWithMappedReason() {
+        let ketch = Ketch(organizationCode: "acme", propertyCode: "prop", environmentCode: "production", identities: [])
+        let plugin = SpyPolicyPlugin()
+        ketch.add(plugin: plugin)
+
+        ketch.notifyExperienceHidden(status: .Close)
+
+        XCTAssertEqual(plugin.hiddenReasons, [.close])
+    }
+
+    func testExperienceHiddenReasonMapsEveryHideExperienceStatus() {
+        let ketch = Ketch(organizationCode: "acme", propertyCode: "prop", environmentCode: "production", identities: [])
+        let plugin = SpyPolicyPlugin()
+        ketch.add(plugin: plugin)
+
+        let statuses: [KetchSDK.HideExperienceStatus] = [
+            .SetConsent, .InvokeRight, .Close, .WillNotShow,
+            .CloseWithoutSettingConsent, .SetSubscriptions, .None
+        ]
+        statuses.forEach { ketch.notifyExperienceHidden(status: $0) }
+
+        XCTAssertEqual(plugin.hiddenReasons, [
+            .setConsent, .invokeRight, .close, .willNotShow,
+            .closeWithoutSettingConsent, .setSubscriptions, .none
+        ])
+    }
+}
+
+// MARK: - Test doubles
+
+private final class SpyPolicyPlugin: PolicyPlugin {
+    override var protocolID: String { "spy-policy-plugin" }
+    override var isApplied: Bool { true }
+
+    private(set) var willShowExperienceCount = 0
+    private(set) var hiddenReasons: [ExperienceHiddenReason] = []
+
+    override func willShowExperience() {
+        willShowExperienceCount += 1
+    }
+
+    override func experienceHidden(reason: ExperienceHiddenReason) {
+        hiddenReasons.append(reason)
+    }
+}

--- a/Tests/KetchSDKTests/PrivacyStringKeyTests.swift
+++ b/Tests/KetchSDKTests/PrivacyStringKeyTests.swift
@@ -1,0 +1,17 @@
+//
+//  PrivacyStringKeyTests.swift
+//  KetchSDKTests
+//
+
+import XCTest
+@testable import KetchSDK
+
+/// The tag writes these exact keys, and the Android and Flutter SDKs read the same
+/// names. A rename here silently breaks every consumer reading the strings back.
+final class PrivacyStringKeyTests: XCTestCase {
+    func testKeysMatchIABSpecification() {
+        XCTAssertEqual(Ketch.PrivacyStringKey.tcfTCString, "IABTCF_TCString")
+        XCTAssertEqual(Ketch.PrivacyStringKey.usPrivacyString, "IABUSPrivacy_String")
+        XCTAssertEqual(Ketch.PrivacyStringKey.gppHDRGppString, "IABGPP_HDR_GppString")
+    }
+}

--- a/Tests/KetchSDKTests/TriggerValidationTests.swift
+++ b/Tests/KetchSDKTests/TriggerValidationTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import KetchSDK
+
+final class TriggerValidationTests: XCTestCase {
+    func testValidFunctionName_lettersDigitsUnderscoreDotDash() {
+        XCTAssertTrue(KetchUI.isValidTriggerFunctionName("myFunction_1.name-2"))
+    }
+
+    func testValidFunctionName_singleCharacter() {
+        XCTAssertTrue(KetchUI.isValidTriggerFunctionName("a"))
+    }
+
+    func testInvalidFunctionName_empty() {
+        XCTAssertFalse(KetchUI.isValidTriggerFunctionName(""))
+    }
+
+    func testInvalidFunctionName_blankWhitespace() {
+        XCTAssertFalse(KetchUI.isValidTriggerFunctionName(" "))
+    }
+
+    func testInvalidFunctionName_containsSpace() {
+        XCTAssertFalse(KetchUI.isValidTriggerFunctionName("my function"))
+    }
+
+    func testInvalidFunctionName_containsSpecialCharacter() {
+        XCTAssertFalse(KetchUI.isValidTriggerFunctionName("my/function"))
+        XCTAssertFalse(KetchUI.isValidTriggerFunctionName("my'function"))
+        XCTAssertFalse(KetchUI.isValidTriggerFunctionName("<script>"))
+    }
+
+    func testTriggerNameRawValue_customMatchesJSShape() {
+        XCTAssertEqual(TriggerName.custom.rawValue, "custom")
+    }
+}

--- a/Tests/KetchSDKTests/TriggerValidationTests.swift
+++ b/Tests/KetchSDKTests/TriggerValidationTests.swift
@@ -31,4 +31,90 @@ final class TriggerValidationTests: XCTestCase {
     func testTriggerNameRawValue_customMatchesJSShape() {
         XCTAssertEqual(TriggerName.custom.rawValue, "custom")
     }
+
+    // MARK: - Trigger state machine
+    //
+    // These drive KetchUI's private bridge-event handler directly, since there is no seam for
+    // injecting a fake WebPresentationItem to exercise the real .configurationLoaded flow.
+
+    private func makeKetchUI() -> KetchUI {
+        let ketch = Ketch(organizationCode: "acme", propertyCode: "prop", environmentCode: "production", identities: [])
+        return KetchUI(ketch: ketch)
+    }
+
+    private let emptyConfiguration = KetchSDK.Configuration(
+        experiences: nil,
+        theme: nil,
+        rights: nil,
+        jurisdiction: nil,
+        purposes: nil
+    )
+
+    func testTrigger_beforeTagBoots_queuesRatherThanFiring() {
+        let ketchUI = makeKetchUI()
+        XCTAssertFalse(ketchUI.isTagBooted)
+
+        let accepted = ketchUI.trigger(triggerName: .custom, functionName: "testFn")
+
+        XCTAssertTrue(accepted)
+        XCTAssertNotNil(ketchUI.pendingTrigger)
+    }
+
+    func testTrigger_afterTagBoots_firesImmediatelyWithoutQueueing() {
+        let ketchUI = makeKetchUI()
+        ketchUI.handle(webPresentationEvent: .configurationLoaded(emptyConfiguration))
+        XCTAssertTrue(ketchUI.isTagBooted)
+
+        let accepted = ketchUI.trigger(triggerName: .custom, functionName: "testFn")
+
+        XCTAssertTrue(accepted)
+        XCTAssertNil(ketchUI.pendingTrigger)
+    }
+
+    func testConfigurationLoaded_drainsAPreviouslyQueuedTrigger() {
+        let ketchUI = makeKetchUI()
+        _ = ketchUI.trigger(triggerName: .custom, functionName: "testFn")
+        XCTAssertNotNil(ketchUI.pendingTrigger)
+
+        ketchUI.handle(webPresentationEvent: .configurationLoaded(emptyConfiguration))
+
+        XCTAssertNil(ketchUI.pendingTrigger)
+    }
+
+    func testConfigurationLoaded_deferredShow_leavesTagBootedTrue() {
+        // Regression test: a deferred first show used to reset isTagBooted (then isConfigLoaded)
+        // back to false, so every later trigger() queued forever and never fired.
+        let ketchUI = makeKetchUI()
+        ketchUI.showConsent() // defers, since the tag hasn't booted yet
+
+        ketchUI.handle(webPresentationEvent: .configurationLoaded(emptyConfiguration))
+
+        XCTAssertTrue(ketchUI.isTagBooted)
+    }
+
+    func testReload_resetsTagBootedState() {
+        let ketchUI = makeKetchUI()
+        ketchUI.handle(webPresentationEvent: .configurationLoaded(emptyConfiguration))
+        XCTAssertTrue(ketchUI.isTagBooted)
+
+        ketchUI.reload()
+
+        XCTAssertFalse(
+            ketchUI.isTagBooted,
+            "a trigger() issued during the reload window must take the cold path, not evaluate JS against a page that hasn't loaded yet"
+        )
+    }
+
+    func testReload_preservesAPendingTrigger() {
+        let ketchUI = makeKetchUI()
+        _ = ketchUI.trigger(triggerName: .custom, functionName: "testFn")
+        XCTAssertNotNil(ketchUI.pendingTrigger)
+
+        ketchUI.reload()
+
+        XCTAssertNotNil(
+            ketchUI.pendingTrigger,
+            "the caller was already told trigger() returned true; a reload must not silently discard it"
+        )
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Code generated by shipbuilder init 1.21.3. DO NOT EDIT. -->

## Description of this change

Top layer of a 3-PR stack for the headless SDK surface. Review this PR's diff against its base (#89).

```
main
 └── #80  native storage dispatch
  └── #89  headless core + tests
   └── #90  policy/trigger parity + privacy strings   ← this PR
```

- Present experience on every show path; dispatch PolicyPlugin lifecycle events (with onShow dedupe)
- `onFunction` rule trigger support; preserve a pending trigger and reset tag-booted state across reload
- Privacy string accessors, with sample and README documentation

## Why is this change being made?

- [ ] Chore (non-functional changes)
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

- Tests: `PolicyPluginDispatchTests`, `TriggerValidationTests`, `PrivacyStringKeyTests`.
- Reviewer: check CI on this PR; review the diff against #89.

## Related issues

None.

## Checklist

- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.
