### PR TITLE
fix: deliver onNativeStoragePut to KetchEventListener conformers

### DIFF
--- a/Sources/KetchSDK/UI/KetchUI.swift
+++ b/Sources/KetchSDK/UI/KetchUI.swift
@@ -328,6 +328,7 @@ public protocol KetchEventListener: AnyObject {
     func onCCPAUpdated(ccpaString: String?)
     func onTCFUpdated(tcfString: String?)
     func onGPPUpdated(gppString: String?)
+    func onNativeStoragePut(key: String, value: String)
 }
 
 public extension KetchEventListener {

--- a/Tests/KetchSDKTests/KetchEventListenerDispatchTests.swift
+++ b/Tests/KetchSDKTests/KetchEventListenerDispatchTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+@testable import KetchSDK
+
+final class KetchEventListenerDispatchTests: XCTestCase {
+
+    /// `KetchUI` stores its listener as `KetchEventListener?` and calls
+    /// `onNativeStoragePut` through that existential. A member declared only in a
+    /// protocol extension dispatches statically there, so the empty default body runs
+    /// and the conformer's implementation is skipped without any compiler diagnostic.
+    /// Calling through the existential — rather than through `SpyEventListener` — is
+    /// what makes this test able to catch that.
+    func testNativeStoragePutReachesConformerThroughExistential() {
+        let spy = SpyEventListener()
+        let listener: KetchEventListener? = spy
+
+        listener?.onNativeStoragePut(key: "IABTCF_TCString", value: "CPabc123")
+
+        XCTAssertEqual(spy.nativeStoragePuts.count, 1)
+        XCTAssertEqual(spy.nativeStoragePuts.first?.key, "IABTCF_TCString")
+        XCTAssertEqual(spy.nativeStoragePuts.first?.value, "CPabc123")
+    }
+
+    /// The extension default keeps `onNativeStoragePut` optional for conformers.
+    /// `MinimalEventListener` omits it, so this file failing to compile is the
+    /// assertion; the call confirms the default is reachable and inert at runtime.
+    func testConformerOmittingNativeStoragePutStillCompilesAndNoOps() {
+        let listener: KetchEventListener? = MinimalEventListener()
+
+        listener?.onNativeStoragePut(key: "key", value: "value")
+    }
+}
+
+// MARK: - Test doubles
+
+private final class SpyEventListener: KetchEventListener {
+    private(set) var nativeStoragePuts: [(key: String, value: String)] = []
+
+    func onNativeStoragePut(key: String, value: String) {
+        nativeStoragePuts.append((key: key, value: value))
+    }
+
+    func onShow() { }
+    func onWillShowExperience(type: KetchSDK.WillShowExperienceType) { }
+    func onHasShownExperience() { }
+    func onDismiss(status: KetchSDK.HideExperienceStatus) { }
+    func onEnvironmentUpdated(environment: String?) { }
+    func onRegionInfoUpdated(regionInfo: String?) { }
+    func onJurisdictionUpdated(jurisdiction: String?) { }
+    func onIdentitiesUpdated(identities: String?) { }
+    func onConsentUpdated(consent: KetchSDK.ConsentStatus) { }
+    func onError(description: String) { }
+    func onCCPAUpdated(ccpaString: String?) { }
+    func onTCFUpdated(tcfString: String?) { }
+    func onGPPUpdated(gppString: String?) { }
+}
+
+/// Deliberately does not implement `onNativeStoragePut`.
+private final class MinimalEventListener: KetchEventListener {
+    func onShow() { }
+    func onWillShowExperience(type: KetchSDK.WillShowExperienceType) { }
+    func onHasShownExperience() { }
+    func onDismiss(status: KetchSDK.HideExperienceStatus) { }
+    func onEnvironmentUpdated(environment: String?) { }
+    func onRegionInfoUpdated(regionInfo: String?) { }
+    func onJurisdictionUpdated(jurisdiction: String?) { }
+    func onIdentitiesUpdated(identities: String?) { }
+    func onConsentUpdated(consent: KetchSDK.ConsentStatus) { }
+    func onError(description: String) { }
+    func onCCPAUpdated(ccpaString: String?) { }
+    func onTCFUpdated(tcfString: String?) { }
+    func onGPPUpdated(gppString: String?) { }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Code generated by shipbuilder init 1.21.3. DO NOT EDIT. -->

## Description of this change

Bottom layer of a 3-PR stack for the headless SDK surface.

`onNativeStoragePut` events are now delivered to `KetchEventListener` conformers, so consumers relying on native storage callbacks receive them.

## Why is this change being made?

- [ ] Chore (non-functional changes)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How was this tested? How can the reviewer verify your testing?

- `KetchEventListenerDispatchTests` covers the dispatch path.
- Reviewer: check CI on this PR.

## Related issues

None.

## Checklist

- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small public API/protocol change with a default implementation; behavior fix for listeners that implement the callback, with targeted unit tests and no auth or data-path changes.
> 
> **Overview**
> **`onNativeStoragePut` is now a required `KetchEventListener` requirement** (with an empty default still provided in a protocol extension), so calls through `KetchUI`’s `KetchEventListener?` existential reach conformers’ implementations instead of only hitting the extension’s static default.
> 
> Adds **`KetchEventListenerDispatchTests`** to lock in existential dispatch and to confirm listeners that omit the method still compile and no-op at runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b2580faa573785ba7a965d3e4d6fa77c4e7c151. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->