### PR TITLE
feat: headless web/v3 API client and instance surface

### DIFF
--- a/Sources/KetchSDK/Core/ApiRequest.swift
+++ b/Sources/KetchSDK/Core/ApiRequest.swift
@@ -8,98 +8,23 @@ import Combine
 
 struct EndPoint {
     private static let defaultScheme = "https"
-    private static let ketchHost = "global.ketchcdn.com"
-    private static let ketchApi = "/web"
-    private static let ketchApiVersion = "v2"
     private static let ketchStaticHost = "cdn.ketchjs.com"
     private static let KetchStaticApi = "/lanyard/static"
 
-    let scheme: String
-    let host: String
-    let path: String
-    let queryItems: [URLQueryItem]
-    
+    let url: URL
+
+    /// Pre-built absolute URL (headless web/v3).
+    init(url: URL) {
+        self.url = url
+    }
+
     static func localizedStrings(languageCode: String) -> EndPoint {
-        EndPoint(
-            scheme: defaultScheme,
-            host: ketchStaticHost,
-            path: [KetchStaticApi, "locales", "\(languageCode).json"].joined(separator: "/"),
-            queryItems: [])
-    }
-
-    static func config(organization: String, property: String) -> EndPoint {
-        EndPoint(
-            scheme: defaultScheme,
-            host: ketchHost,
-            path: [ketchApi, ketchApiVersion, "config", organization, property, "config.json"].joined(separator: "/"),
-            queryItems: [URLQueryItem(name:"language", value:Locale.preferredLanguages[0])]
-        )
-    }
-
-    static func fullConfig(
-        organization: String,
-        property: String,
-        environment: String,
-        hash: Int,
-        jurisdiction: String,
-        language: String
-    ) -> EndPoint {
-        EndPoint(
-            scheme: defaultScheme,
-            host: ketchHost,
-            path: [
-                ketchApi, ketchApiVersion,
-                "config", organization, property, environment, String(hash), jurisdiction, language,
-                "config.json"
-            ].joined(separator: "/"),
-            queryItems: []
-        )
-    }
-
-    static func getConsent(organization: String) -> EndPoint {
-        EndPoint(
-            scheme: defaultScheme,
-            host: ketchHost,
-            path: [ketchApi, ketchApiVersion, "consent", organization, "get"].joined(separator: "/"),
-            queryItems: []
-        )
-    }
-
-    static func updateConsent(organization: String) -> EndPoint {
-        EndPoint(
-            scheme: defaultScheme,
-            host: ketchHost,
-            path: [ketchApi, ketchApiVersion, "consent", organization, "update"].joined(separator: "/"),
-            queryItems: []
-        )
-    }
-
-    static func invokeRights(organization: String) -> EndPoint {
-        EndPoint(
-            scheme: defaultScheme,
-            host: ketchHost,
-            path: [ketchApi, ketchApiVersion, "rights", organization, "invoke"].joined(separator: "/"),
-            queryItems: []
-        )
-    }
-
-    static func getVendors() -> EndPoint {
-        EndPoint(
-            scheme: defaultScheme,
-            host: ketchHost,
-            path: [ketchApi, ketchApiVersion, "gvl", "vendor-list.json"].joined(separator: "/"),
-            queryItems: []
-        )
-    }
-
-    var url: URL? {
+        let path = [KetchStaticApi, "locales", "\(languageCode).json"].joined(separator: "/")
         var components = URLComponents()
-        components.scheme = scheme
-        components.host = host
+        components.scheme = defaultScheme
+        components.host = ketchStaticHost
         components.path = path
-        components.queryItems = queryItems
-
-        return components.url
+        return EndPoint(url: components.url!)
     }
 }
 
@@ -168,7 +93,7 @@ class DefaultApiClient: ApiClient {
     }
 
     private static func urlRequest(with request: ApiRequest) -> URLRequest? {
-        guard let url = request.endPoint.url else { return nil }
+        let url = request.endPoint.url
         
         var urlRequest = URLRequest(url: url)
 
@@ -181,10 +106,12 @@ class DefaultApiClient: ApiClient {
             forHTTPHeaderField: ApiRequest.HeaderField.accept
         )
 
-        urlRequest.setValue(
-            ApiRequest.HeaderValue.applicationJson,
-            forHTTPHeaderField: ApiRequest.HeaderField.contentType
-        )
+        if request.body != nil {
+            urlRequest.setValue(
+                ApiRequest.HeaderValue.contentTypeJson,
+                forHTTPHeaderField: ApiRequest.HeaderField.contentType
+            )
+        }
 
         return urlRequest
     }

--- a/Sources/KetchSDK/Core/Entities/Configuration.swift
+++ b/Sources/KetchSDK/Core/Entities/Configuration.swift
@@ -9,11 +9,18 @@ extension KetchSDK {
     public struct Configuration: Codable {
         public let experiences: Experience?
         public let theme: Theme?
-        
+
         //Legacy
         public let rights: [Right]?
         public let jurisdiction: Jurisdiction?
         public let purposes: [Purpose]?
+    }
+}
+
+extension KetchSDK.Configuration {
+    /// Resolved jurisdiction code: the CDN's specific jurisdiction if set, else its default.
+    func jurisdictionCode() -> String? {
+        jurisdiction?.code ?? jurisdiction?.defaultJurisdictionCode
     }
 }
 

--- a/Sources/KetchSDK/Core/Entities/FullConfigurationRequest.swift
+++ b/Sources/KetchSDK/Core/Entities/FullConfigurationRequest.swift
@@ -51,7 +51,7 @@ extension KetchSDK.FullConfigurationRequest {
         // A missing language must not silently drop env/jurisdiction to the short path —
         // synthesize it from the device locale so the long path is always used once both
         // env and jurisdiction are known.
-        let language = languageCode?.isEmpty == false ? languageCode! : Self.deviceLanguageTag()
+        let language = languageCode?.isEmpty == false ? Self.formatLanguageTag(languageCode!) : Self.deviceLanguageTag()
         return (env, jurisdiction, language)
     }
 
@@ -90,7 +90,7 @@ extension KetchSDK.FullConfigurationRequest {
     func configQueryItems(deviceLanguage: () -> String = Self.deviceLanguageTag) -> [URLQueryItem] {
         var items: [URLQueryItem] = []
         if configPathSegment() == nil {
-            let language = languageCode?.isEmpty == false ? languageCode! : deviceLanguage()
+            let language = languageCode?.isEmpty == false ? Self.formatLanguageTag(languageCode!) : deviceLanguage()
             items.append(URLQueryItem(name: "language", value: language))
             if let jurisdictionCode, !jurisdictionCode.isEmpty {
                 items.append(URLQueryItem(name: "jurisdiction", value: jurisdictionCode))

--- a/Sources/KetchSDK/Core/Entities/FullConfigurationRequest.swift
+++ b/Sources/KetchSDK/Core/Entities/FullConfigurationRequest.swift
@@ -1,0 +1,94 @@
+//
+//  FullConfigurationRequest.swift
+//  KetchSDK
+//
+
+import Foundation
+
+extension KetchSDK {
+    /// Parameters for v3 `getFullConfiguration` (ketch-types `GetFullConfigurationRequest`).
+    public struct FullConfigurationRequest: Sendable {
+        public let organizationCode: String
+        public let propertyCode: String
+        public let environmentCode: String?
+        public let jurisdictionCode: String?
+        public let languageCode: String?
+        public let hash: String?
+        public let regionCode: String?
+
+        public init(
+            organizationCode: String,
+            propertyCode: String,
+            environmentCode: String? = nil,
+            jurisdictionCode: String? = nil,
+            languageCode: String? = nil,
+            hash: String? = nil,
+            regionCode: String? = nil
+        ) {
+            self.organizationCode = organizationCode
+            self.propertyCode = propertyCode
+            self.environmentCode = environmentCode
+            self.jurisdictionCode = jurisdictionCode
+            self.languageCode = languageCode
+            self.hash = hash
+            self.regionCode = regionCode
+        }
+    }
+}
+
+extension KetchSDK.FullConfigurationRequest {
+    /// The env/jurisdiction/language segment appended to the full-config path, or `nil` if any of
+    /// the three is absent or blank — matching ketch-tag, which treats a blank value the same as
+    /// unset. Single source of truth so the actual HTTP path (`HeadlessApiClient`) and any cache
+    /// keyed on it (`Ketch.buildConfigCacheKey`) can never disagree about what "the same request"
+    /// means.
+    func configPathSegment() -> (env: String, jurisdiction: String, language: String)? {
+        guard let env = environmentCode, !env.isEmpty,
+              let jurisdiction = jurisdictionCode, !jurisdiction.isEmpty,
+              let language = languageCode, !language.isEmpty
+        else {
+            return nil
+        }
+        return (env, jurisdiction, language)
+    }
+
+    /// Non-blank hash, or `nil` — a blank hash is treated the same as an absent one.
+    func normalizedHash() -> String? {
+        guard let hash, !hash.isEmpty else { return nil }
+        return hash
+    }
+
+    /// Matches ketch-tag's `formatLanguage` ("fr-CA"), tolerant of `Locale.preferredLanguages`' "fr_CA" form.
+    static func formatLanguageTag(_ raw: String) -> String {
+        guard !raw.isEmpty else { return "en" }
+        let parts = raw.split(whereSeparator: { $0 == "-" || $0 == "_" })
+        let root = parts[0].lowercased()
+        guard parts.count > 1, !parts[1].isEmpty else { return root }
+        return "\(root)-\(parts[1].uppercased())"
+    }
+
+    static func deviceLanguageTag() -> String {
+        formatLanguageTag(Locale.preferredLanguages.first ?? "en")
+    }
+
+    /// Query items for `getFullConfiguration`. On the short path (see `configPathSegment`), a
+    /// missing `languageCode` defaults to `deviceLanguage` rather than "en". Shared with
+    /// `Ketch.buildConfigCacheKey`.
+    func configQueryItems(deviceLanguage: () -> String = Self.deviceLanguageTag) -> [URLQueryItem] {
+        var items: [URLQueryItem] = []
+        if configPathSegment() == nil {
+            let language = languageCode?.isEmpty == false ? languageCode! : deviceLanguage()
+            items.append(URLQueryItem(name: "language", value: language))
+            if let jurisdictionCode, !jurisdictionCode.isEmpty {
+                items.append(URLQueryItem(name: "jurisdiction", value: jurisdictionCode))
+            }
+            if let regionCode, !regionCode.isEmpty {
+                items.append(URLQueryItem(name: "region", value: regionCode))
+            }
+        }
+        if let hash = normalizedHash() {
+            items.append(URLQueryItem(name: "hash", value: hash))
+        }
+        return items
+    }
+}

--- a/Sources/KetchSDK/Core/Entities/FullConfigurationRequest.swift
+++ b/Sources/KetchSDK/Core/Entities/FullConfigurationRequest.swift
@@ -44,11 +44,14 @@ extension KetchSDK.FullConfigurationRequest {
     /// means.
     func configPathSegment() -> (env: String, jurisdiction: String, language: String)? {
         guard let env = environmentCode, !env.isEmpty,
-              let jurisdiction = jurisdictionCode, !jurisdiction.isEmpty,
-              let language = languageCode, !language.isEmpty
+              let jurisdiction = jurisdictionCode, !jurisdiction.isEmpty
         else {
             return nil
         }
+        // A missing language must not silently drop env/jurisdiction to the short path —
+        // synthesize it from the device locale so the long path is always used once both
+        // env and jurisdiction are known.
+        let language = languageCode?.isEmpty == false ? languageCode! : Self.deviceLanguageTag()
         return (env, jurisdiction, language)
     }
 
@@ -59,12 +62,22 @@ extension KetchSDK.FullConfigurationRequest {
     }
 
     /// Matches ketch-tag's `formatLanguage` ("fr-CA"), tolerant of `Locale.preferredLanguages`' "fr_CA" form.
+    /// Preserves a script subtag (4 letters, e.g. "Hans") in title case and a region subtag
+    /// (2 letters or 3 digits, e.g. "CN"/"419") uppercased, so multi-part tags like "zh-Hans-CN"
+    /// survive intact instead of collapsing to "zh-HANS" with the region silently dropped.
     static func formatLanguageTag(_ raw: String) -> String {
         guard !raw.isEmpty else { return "en" }
-        let parts = raw.split(whereSeparator: { $0 == "-" || $0 == "_" })
-        let root = parts[0].lowercased()
-        guard parts.count > 1, !parts[1].isEmpty else { return root }
-        return "\(root)-\(parts[1].uppercased())"
+        let parts = raw.split(whereSeparator: { $0 == "-" || $0 == "_" }).map(String.init)
+        guard let first = parts.first, !first.isEmpty else { return "en" }
+        var result = [first.lowercased()]
+        for part in parts.dropFirst() {
+            if part.count == 4, part.allSatisfy(\.isLetter) {
+                result.append(part.prefix(1).uppercased() + part.dropFirst().lowercased())
+            } else if (part.count == 2 && part.allSatisfy(\.isLetter)) || (part.count == 3 && part.allSatisfy(\.isNumber)) {
+                result.append(part.uppercased())
+            }
+        }
+        return result.joined(separator: "-")
     }
 
     static func deviceLanguageTag() -> String {

--- a/Sources/KetchSDK/Core/Entities/InvokeRight.swift
+++ b/Sources/KetchSDK/Core/Entities/InvokeRight.swift
@@ -35,6 +35,122 @@ extension KetchSDK {
     }
 }
 
+extension KetchSDK {
+    /// ketch-types `InvokeRightRequest`
+    public struct InvokeRightRequest: Codable {
+        public let organizationCode: String
+        public let controllerCode: String?
+        public let propertyCode: String
+        public let environmentCode: String
+        public let identities: [String: String]
+        public let invokedAt: Int?
+        public let jurisdictionCode: String
+        public let rightCode: String
+        public let user: DataSubject
+        public let recaptchaToken: String?
+        public let regionCode: String?
+        public let isAuthenticated: Bool?
+
+        public init(
+            organizationCode: String,
+            propertyCode: String,
+            environmentCode: String,
+            identities: [String: String],
+            jurisdictionCode: String,
+            rightCode: String,
+            user: DataSubject,
+            controllerCode: String? = nil,
+            invokedAt: Int? = nil,
+            recaptchaToken: String? = nil,
+            regionCode: String? = nil,
+            isAuthenticated: Bool? = nil
+        ) {
+            self.organizationCode = organizationCode
+            self.controllerCode = controllerCode
+            self.propertyCode = propertyCode
+            self.environmentCode = environmentCode
+            self.identities = identities
+            self.invokedAt = invokedAt
+            self.jurisdictionCode = jurisdictionCode
+            self.rightCode = rightCode
+            self.user = user
+            self.recaptchaToken = recaptchaToken
+            self.regionCode = regionCode
+            self.isAuthenticated = isAuthenticated
+        }
+    }
+
+    /// ketch-types `DataSubject`
+    public struct DataSubject: Codable {
+        public let email: String
+        public let firstName: String
+        public let lastName: String
+        public let country: String?
+        public let stateRegion: String?
+        public let city: String?
+        public let description: String?
+        public let phone: String?
+        public let postalCode: String?
+        public let addressLine1: String?
+        public let addressLine2: String?
+
+        public init(
+            email: String,
+            firstName: String,
+            lastName: String,
+            country: String? = nil,
+            stateRegion: String? = nil,
+            city: String? = nil,
+            description: String? = nil,
+            phone: String? = nil,
+            postalCode: String? = nil,
+            addressLine1: String? = nil,
+            addressLine2: String? = nil
+        ) {
+            self.email = email
+            self.firstName = firstName
+            self.lastName = lastName
+            self.country = country
+            self.stateRegion = stateRegion
+            self.city = city
+            self.description = description
+            self.phone = phone
+            self.postalCode = postalCode
+            self.addressLine1 = addressLine1
+            self.addressLine2 = addressLine2
+        }
+    }
+}
+
+extension KetchSDK.InvokeRightRequest {
+    /// Builds a headless request from the legacy `InvokeRightConfig` (WebView-era shape).
+    init(organizationCode: String, config: KetchSDK.InvokeRightConfig) {
+        let user = config.user
+        self.init(
+            organizationCode: organizationCode,
+            propertyCode: config.propertyCode,
+            environmentCode: config.environmentCode,
+            identities: config.identities,
+            jurisdictionCode: config.jurisdictionCode,
+            rightCode: config.rightCode ?? "",
+            user: KetchSDK.DataSubject(
+                email: user.email,
+                firstName: user.first,
+                lastName: user.last,
+                country: user.country,
+                stateRegion: user.stateRegion,
+                description: user.description,
+                phone: user.phone,
+                postalCode: user.postalCode,
+                addressLine1: user.addressLine1,
+                addressLine2: user.addressLine2
+            ),
+            invokedAt: config.invokedAt,
+            regionCode: nil
+        )
+    }
+}
+
 extension KetchSDK.InvokeRightConfig {
     public struct User: Codable {
         public let email: String

--- a/Sources/KetchSDK/Core/Entities/Location.swift
+++ b/Sources/KetchSDK/Core/Entities/Location.swift
@@ -1,0 +1,57 @@
+//
+//  Location.swift
+//  KetchSDK
+//
+
+import Foundation
+
+extension KetchSDK {
+    /// GeoIP details from `GET /ip` (ketch-types `IPInfo` / `GetLocationResponse`).
+    public struct IPInfo: Codable, Sendable {
+        public let ip: String?
+        public let hostname: String?
+        public let continentCode: String?
+        public let continentName: String?
+        public let countryCode: String?
+        public let countryName: String?
+        public let regionCode: String?
+        public let regionName: String?
+        public let city: String?
+        public let postalCode: String?
+        public let timezone: String?
+    }
+
+    /// Response from headless `getLocation()`.
+    public struct LocationResponse: Codable, Sendable {
+        public let location: IPInfo?
+
+        public init(location: IPInfo?) {
+            self.location = location
+        }
+
+        public init(from decoder: Decoder) throws {
+            if let container = try? decoder.container(keyedBy: CodingKeys.self),
+               let nested = try? container.decode(IPInfo.self, forKey: .location) {
+                location = nested
+                return
+            }
+            location = try IPInfo(from: decoder)
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case location
+        }
+    }
+}
+
+extension KetchSDK.IPInfo {
+    /// Combined ISO region code, e.g. "US-CA", or the country alone when no subdivision is known.
+    func toRegionCode() -> String? {
+        guard let country = countryCode, !country.isEmpty else {
+            guard let region = regionCode, !region.isEmpty else { return nil }
+            return region
+        }
+        guard let region = regionCode, !region.isEmpty else { return country }
+        return "\(country)-\(region)"
+    }
+}

--- a/Sources/KetchSDK/Core/Entities/Location.swift
+++ b/Sources/KetchSDK/Core/Entities/Location.swift
@@ -30,10 +30,15 @@ extension KetchSDK {
         }
 
         public init(from decoder: Decoder) throws {
-            if let container = try? decoder.container(keyedBy: CodingKeys.self),
-               let nested = try? container.decode(IPInfo.self, forKey: .location) {
-                location = nested
-                return
+            if let container = try? decoder.container(keyedBy: CodingKeys.self) {
+                if let nested = try? container.decode(IPInfo.self, forKey: .location) {
+                    location = nested
+                    return
+                }
+                if (try? container.decodeNil(forKey: .location)) == true {
+                    location = nil
+                    return
+                }
             }
             location = try IPInfo(from: decoder)
         }

--- a/Sources/KetchSDK/Core/Entities/PreferenceQR.swift
+++ b/Sources/KetchSDK/Core/Entities/PreferenceQR.swift
@@ -1,0 +1,40 @@
+//
+//  PreferenceQR.swift
+//  KetchSDK
+//
+
+import Foundation
+
+extension KetchSDK {
+    /// ketch-types `GetPreferenceQRRequest`
+    public struct PreferenceQRRequest {
+        public let organizationCode: String
+        public let propertyCode: String
+        public let environmentCode: String?
+        public let imageSize: Int?
+        public let path: String?
+        public let backgroundColor: String?
+        public let foregroundColor: String?
+        public let parameters: [String: String]
+
+        public init(
+            organizationCode: String,
+            propertyCode: String,
+            environmentCode: String? = nil,
+            imageSize: Int? = nil,
+            path: String? = nil,
+            backgroundColor: String? = nil,
+            foregroundColor: String? = nil,
+            parameters: [String: String] = [:]
+        ) {
+            self.organizationCode = organizationCode
+            self.propertyCode = propertyCode
+            self.environmentCode = environmentCode
+            self.imageSize = imageSize
+            self.path = path
+            self.backgroundColor = backgroundColor
+            self.foregroundColor = foregroundColor
+            self.parameters = parameters
+        }
+    }
+}

--- a/Sources/KetchSDK/Core/Entities/Subscriptions.swift
+++ b/Sources/KetchSDK/Core/Entities/Subscriptions.swift
@@ -1,0 +1,49 @@
+//
+//  Subscriptions.swift
+//  KetchSDK
+//
+
+import Foundation
+
+extension KetchSDK {
+    /// ketch-types `GetSubscriptionsRequest` / `SetSubscriptionsRequest`
+    public struct SubscriptionsRequest: Codable {
+        public let organizationCode: String
+        public let controllerCode: String?
+        public let propertyCode: String?
+        public let environmentCode: String?
+        public let identities: [String: String]?
+        public let topics: [String: [String: String]]?
+        public let controls: [String: [String: String]]?
+        public let collectedAt: Int?
+        public let jurisdictionCode: String?
+        public let regionCode: String?
+
+        public init(
+            organizationCode: String,
+            propertyCode: String? = nil,
+            environmentCode: String? = nil,
+            identities: [String: String]? = nil,
+            topics: [String: [String: String]]? = nil,
+            controls: [String: [String: String]]? = nil,
+            controllerCode: String? = nil,
+            collectedAt: Int? = nil,
+            jurisdictionCode: String? = nil,
+            regionCode: String? = nil
+        ) {
+            self.organizationCode = organizationCode
+            self.propertyCode = propertyCode
+            self.environmentCode = environmentCode
+            self.identities = identities
+            self.topics = topics
+            self.controls = controls
+            self.controllerCode = controllerCode
+            self.collectedAt = collectedAt
+            self.jurisdictionCode = jurisdictionCode
+            self.regionCode = regionCode
+        }
+    }
+
+    /// ketch-types `GetSubscriptionsResponse`
+    public typealias SubscriptionsResponse = SubscriptionsRequest
+}

--- a/Sources/KetchSDK/Core/HeadlessApiClient.swift
+++ b/Sources/KetchSDK/Core/HeadlessApiClient.swift
@@ -85,7 +85,7 @@ final class HeadlessApiClient {
             request: .init(
                 organizationCode: organization,
                 propertyCode: property,
-                languageCode: Locale.preferredLanguages[0]
+                languageCode: KetchSDK.FullConfigurationRequest.deviceLanguageTag()
             )
         )
     }

--- a/Sources/KetchSDK/Core/HeadlessApiClient.swift
+++ b/Sources/KetchSDK/Core/HeadlessApiClient.swift
@@ -1,0 +1,416 @@
+//
+//  HeadlessApiClient.swift
+//  KetchSDK
+//
+//  Native HTTP client mirroring ketch-tag KetchWebAPI (web/v3).
+//
+
+import Combine
+import Foundation
+
+/// Builds v3 CDN URLs and performs headless API calls.
+final class HeadlessApiClient {
+    typealias KetchError = KetchSDK.KetchError
+    typealias Configuration = KetchSDK.Configuration
+    typealias ConsentStatus = KetchSDK.ConsentStatus
+    typealias ConsentConfig = KetchSDK.ConsentConfig
+    typealias ConsentUpdate = KetchSDK.ConsentUpdate
+
+    private let baseURL: URL
+    private let apiClient: ApiClient
+    private let session: URLSession
+
+    init(
+        dataCenter: KetchDataCenter = .us,
+        apiClient: ApiClient = DefaultApiClient(),
+        session: URLSession = .shared
+    ) {
+        self.baseURL = dataCenter.baseURL
+        self.apiClient = apiClient
+        self.session = session
+    }
+
+    func getLocation() -> AnyPublisher<KetchSDK.LocationResponse, KetchError> {
+        get(path: "/ip")
+            .decode(type: KetchSDK.LocationResponse.self, decoder: JSONDecoder())
+            .mapError(KetchError.init)
+            .eraseToAnyPublisher()
+    }
+
+    func getBootstrapConfiguration(
+        organization: String,
+        property: String
+    ) -> AnyPublisher<Configuration, KetchError> {
+        get(path: "/config/\(organization)/\(property)/boot.json")
+            .decode(type: Configuration.self, decoder: JSONDecoder())
+            .mapError(KetchError.init)
+            .eraseToAnyPublisher()
+    }
+
+    func getFullConfiguration(
+        request: KetchSDK.FullConfigurationRequest
+    ) -> AnyPublisher<Configuration, KetchError> {
+        var path = "/config/\(request.organizationCode)/\(request.propertyCode)"
+        if let segment = request.configPathSegment() {
+            path += "/\(segment.env)/\(segment.jurisdiction)/\(segment.language)"
+        }
+        path += "/config.json"
+        return get(path: path, queryItems: request.configQueryItems())
+            .decode(type: Configuration.self, decoder: JSONDecoder())
+            .mapError(KetchError.init)
+            .eraseToAnyPublisher()
+    }
+
+    func getConsent(config: ConsentConfig) -> AnyPublisher<ConsentStatus, KetchError> {
+        let path = "/consent/\(config.organizationCode)/get"
+        guard let body = try? JSONEncoder().encode(ConsentConfigPayload(config: config)) else {
+            return Fail(error: KetchError.requestError).eraseToAnyPublisher()
+        }
+        return postConsent(path: path, body: body, config: config)
+    }
+
+    /// Returns server consent including computed `protocols`; omits `protocols` from request body.
+    func setConsent(update: ConsentUpdate) -> AnyPublisher<ConsentStatus, KetchError> {
+        let path = "/consent/\(update.organizationCode)/update"
+        guard let body = try? JSONEncoder().encode(SetConsentPayload(update: update)) else {
+            return Fail(error: KetchError.requestError).eraseToAnyPublisher()
+        }
+        return postSetConsent(path: path, body: body, fallback: update)
+    }
+
+    // MARK: - Legacy v3 endpoints (used by existing KetchApiRequest)
+
+    func fetchConfig(organization: String, property: String) -> AnyPublisher<Configuration, KetchError> {
+        getFullConfiguration(
+            request: .init(
+                organizationCode: organization,
+                propertyCode: property,
+                languageCode: Locale.preferredLanguages[0]
+            )
+        )
+    }
+
+    func fetchConfig(
+        organization: String,
+        property: String,
+        environment: String,
+        hash: String,
+        jurisdiction: String,
+        language: String
+    ) -> AnyPublisher<Configuration, KetchError> {
+        getFullConfiguration(
+            request: .init(
+                organizationCode: organization,
+                propertyCode: property,
+                environmentCode: environment,
+                jurisdictionCode: jurisdiction,
+                languageCode: language,
+                hash: hash
+            )
+        )
+    }
+
+    func invokeRight(request: KetchSDK.InvokeRightRequest) -> AnyPublisher<Void, KetchError> {
+        let path = "/rights/\(request.organizationCode)/invoke"
+        guard let body = try? JSONEncoder().encode(request) else {
+            return Fail(error: KetchError.requestError).eraseToAnyPublisher()
+        }
+        return postVoid(path: path, body: body)
+    }
+
+    func getSubscriptions(
+        request: KetchSDK.SubscriptionsRequest
+    ) -> AnyPublisher<KetchSDK.SubscriptionsResponse, KetchError> {
+        let path = "/subscriptions/\(request.organizationCode)/get"
+        guard let body = try? JSONEncoder().encode(request) else {
+            return Fail(error: KetchError.requestError).eraseToAnyPublisher()
+        }
+        return post(path: path, body: body)
+            .decode(type: KetchSDK.SubscriptionsResponse.self, decoder: JSONDecoder())
+            .mapError(KetchError.init)
+            .eraseToAnyPublisher()
+    }
+
+    func setSubscriptions(request: KetchSDK.SubscriptionsRequest) -> AnyPublisher<Void, KetchError> {
+        let path = "/subscriptions/\(request.organizationCode)/update"
+        guard let body = try? JSONEncoder().encode(request) else {
+            return Fail(error: KetchError.requestError).eraseToAnyPublisher()
+        }
+        return postVoid(path: path, body: body)
+    }
+
+    func invokeRights(organization: String, config: KetchSDK.InvokeRightConfig) -> AnyPublisher<Void, KetchError> {
+        invokeRight(request: .init(organizationCode: organization, config: config))
+    }
+
+    func getPreferenceQRUrl(request: KetchSDK.PreferenceQRRequest) -> URL? {
+        var pairs: [(String, String)] = []
+        if let environmentCode = request.environmentCode {
+            pairs.append(("env", environmentCode))
+        }
+        if let imageSize = request.imageSize {
+            pairs.append(("size", String(imageSize)))
+        }
+        if let path = request.path {
+            pairs.append(("path", path))
+        }
+        if let backgroundColor = request.backgroundColor {
+            pairs.append(("bgcolor", backgroundColor))
+        }
+        if let foregroundColor = request.foregroundColor {
+            pairs.append(("fgcolor", foregroundColor))
+        }
+        for (key, value) in request.parameters {
+            pairs.append((key, value))
+        }
+        guard let base = buildURL(
+            path: "/qr/\(request.organizationCode)/\(request.propertyCode)/preferences.png"
+        ) else {
+            return nil
+        }
+        guard !pairs.isEmpty else {
+            return base
+        }
+        let query = pairs
+            .map { "\($0.0)=\(Self.encodeURIComponent($0.1))" }
+            .joined(separator: "&")
+        return URL(string: base.absoluteString + "?" + query)
+    }
+
+    /// Matches JavaScript `encodeURIComponent` (ketch-tag `URL.searchParams`).
+    private static func encodeURIComponent(_ value: String) -> String {
+        var allowed = CharacterSet.alphanumerics
+        allowed.insert(charactersIn: "-_.~")
+        return value.addingPercentEncoding(withAllowedCharacters: allowed) ?? value
+    }
+
+    func getVendors() -> AnyPublisher<KetchSDK.Vendors, KetchError> {
+        get(path: "/gvl/vendor-list.json")
+            .decode(type: KetchSDK.Vendors.self, decoder: JSONDecoder())
+            .mapError(KetchError.init)
+            .eraseToAnyPublisher()
+    }
+
+    // MARK: - Networking
+
+    private func get(path: String, queryItems: [URLQueryItem] = []) -> AnyPublisher<Data, KetchError> {
+        guard let url = buildURL(path: path, queryItems: queryItems) else {
+            return Fail(error: KetchError.requestError).eraseToAnyPublisher()
+        }
+        let request = ApiRequest(
+            endPoint: EndPoint(url: url),
+            method: .get,
+            body: nil
+        )
+        return apiClient.execute(request: request)
+            .mapError { KetchError(with: $0) }
+            .eraseToAnyPublisher()
+    }
+
+    private func post(path: String, body: Data) -> AnyPublisher<Data, KetchError> {
+        guard let url = buildURL(path: path) else {
+            return Fail(error: KetchError.requestError).eraseToAnyPublisher()
+        }
+        let request = ApiRequest(
+            endPoint: EndPoint(url: url),
+            method: .post,
+            body: body
+        )
+        return apiClient.execute(request: request)
+            .mapError { KetchError(with: $0) }
+            .eraseToAnyPublisher()
+    }
+
+    private func postVoid(path: String, body: Data) -> AnyPublisher<Void, KetchError> {
+        guard let url = buildURL(path: path) else {
+            return Fail(error: KetchError.requestError).eraseToAnyPublisher()
+        }
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "POST"
+        urlRequest.httpBody = body
+        applyJSONHeaders(&urlRequest)
+
+        return session.dataTaskPublisher(for: urlRequest)
+            .tryMap { output -> Void in
+                if let http = output.response as? HTTPURLResponse,
+                   !(200..<300).contains(http.statusCode) {
+                    throw URLError(.badServerResponse)
+                }
+                return ()
+            }
+            .mapError(KetchError.init)
+            .eraseToAnyPublisher()
+    }
+
+    private func postConsent(
+        path: String,
+        body: Data,
+        config: ConsentConfig
+    ) -> AnyPublisher<ConsentStatus, KetchError> {
+        guard let url = buildURL(path: path) else {
+            return Fail(error: KetchError.requestError).eraseToAnyPublisher()
+        }
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "POST"
+        urlRequest.httpBody = body
+        applyJSONHeaders(&urlRequest)
+
+        return session.dataTaskPublisher(for: urlRequest)
+            .tryMap { output -> ConsentStatus in
+                let data = output.data
+                if let http = output.response as? HTTPURLResponse,
+                   !(200..<300).contains(http.statusCode) {
+                    throw URLError(.badServerResponse)
+                }
+                if data.isEmpty || String(data: data, encoding: .utf8) == "null" {
+                    return Self.emptyConsentStatus(for: config)
+                }
+                if let decoded = try? JSONDecoder().decode(ConsentStatus.self, from: data),
+                   Self.hasUsableConsentFields(decoded) {
+                    return decoded
+                }
+                return Self.emptyConsentStatus(for: config)
+            }
+            .mapError(KetchError.init)
+            .eraseToAnyPublisher()
+    }
+
+    private func postSetConsent(
+        path: String,
+        body: Data,
+        fallback: ConsentUpdate
+    ) -> AnyPublisher<ConsentStatus, KetchError> {
+        guard let url = buildURL(path: path) else {
+            return Fail(error: KetchError.requestError).eraseToAnyPublisher()
+        }
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "POST"
+        urlRequest.httpBody = body
+        applyJSONHeaders(&urlRequest)
+
+        return session.dataTaskPublisher(for: urlRequest)
+            .tryMap { output -> ConsentStatus in
+                let data = output.data
+                if let http = output.response as? HTTPURLResponse,
+                   !(200..<300).contains(http.statusCode) {
+                    throw URLError(.badServerResponse)
+                }
+                if let decoded = try? JSONDecoder().decode(ConsentStatus.self, from: data),
+                   Self.hasUsableConsentFields(decoded) {
+                    return Self.mergingProtocols(from: decoded, fallback: fallback)
+                }
+                return Self.consentStatus(from: fallback)
+            }
+            .mapError(KetchError.init)
+            .eraseToAnyPublisher()
+    }
+
+    func buildURL(path: String, queryItems: [URLQueryItem] = []) -> URL? {
+        guard var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: true) else {
+            return nil
+        }
+        let normalized = path.hasPrefix("/") ? path : "/\(path)"
+        let basePath = components.path.hasSuffix("/") ? String(components.path.dropLast()) : components.path
+        components.path = basePath + normalized
+        if !queryItems.isEmpty {
+            components.queryItems = queryItems
+        }
+        return components.url
+    }
+
+    private func applyJSONHeaders(_ request: inout URLRequest) {
+        request.setValue(
+            ApiRequest.HeaderValue.applicationJson,
+            forHTTPHeaderField: ApiRequest.HeaderField.accept
+        )
+        request.setValue(
+            ApiRequest.HeaderValue.contentTypeJson,
+            forHTTPHeaderField: ApiRequest.HeaderField.contentType
+        )
+    }
+
+    private static func hasUsableConsentFields(_ status: ConsentStatus) -> Bool {
+        if let purposes = status.purposes, !purposes.isEmpty { return true }
+        if let vendors = status.vendors, !vendors.isEmpty { return true }
+        if let protocols = status.protocols, !protocols.isEmpty { return true }
+        return false
+    }
+
+    private static func emptyConsentStatus(for config: ConsentConfig) -> ConsentStatus {
+        ConsentStatus(purposes: [:], vendors: nil, protocols: nil)
+    }
+
+    private static func consentStatus(from update: ConsentUpdate) -> ConsentStatus {
+        let purposes = update.purposes.reduce(into: [String: Bool]()) { result, entry in
+            result[entry.key] = entry.value.allowed
+        }
+        return ConsentStatus(
+            purposes: purposes,
+            vendors: update.vendors,
+            protocols: update.protocols
+        )
+    }
+
+    /// Keeps server-computed protocols when present; otherwise preserves caller-supplied strings (e.g. GPP).
+    private static func mergingProtocols(from status: ConsentStatus, fallback: ConsentUpdate) -> ConsentStatus {
+        guard let callerProtocols = fallback.protocols, !callerProtocols.isEmpty else {
+            return status
+        }
+        if let responseProtocols = status.protocols, !responseProtocols.isEmpty {
+            return status
+        }
+        return ConsentStatus(
+            purposes: status.purposes,
+            vendors: status.vendors,
+            protocols: callerProtocols
+        )
+    }
+}
+
+// MARK: - Request payloads
+
+private struct ConsentConfigPayload: Encodable {
+    let organizationCode: String
+    let propertyCode: String
+    let environmentCode: String
+    let jurisdictionCode: String
+    let identities: [String: String]
+    let purposes: [String: KetchSDK.ConsentConfig.PurposeLegalBasis]
+
+    init(config: KetchSDK.ConsentConfig) {
+        organizationCode = config.organizationCode
+        propertyCode = config.propertyCode
+        environmentCode = config.environmentCode
+        jurisdictionCode = config.jurisdictionCode
+        identities = config.identities
+        purposes = config.purposes
+    }
+}
+
+private struct SetConsentPayload: Encodable {
+    let organizationCode: String
+    let propertyCode: String
+    let environmentCode: String
+    let identities: [String: String]
+    let jurisdictionCode: String
+    let migrationOption: KetchSDK.ConsentUpdate.MigrationOption
+    let purposes: [String: KetchSDK.ConsentUpdate.PurposeAllowedLegalBasis]
+    let vendors: [String]?
+
+    init(update: KetchSDK.ConsentUpdate) {
+        organizationCode = update.organizationCode
+        propertyCode = update.propertyCode
+        environmentCode = update.environmentCode
+        identities = update.identities
+        jurisdictionCode = update.jurisdictionCode
+        migrationOption = update.migrationOption
+        purposes = update.purposes
+        vendors = update.vendors
+    }
+}
+
+extension KetchSDK.KetchError {
+    fileprivate init(with error: ApiClientError) {
+        self.init(with: error as Error)
+    }
+}

--- a/Sources/KetchSDK/Core/HeadlessApiClient.swift
+++ b/Sources/KetchSDK/Core/HeadlessApiClient.swift
@@ -18,16 +18,13 @@ final class HeadlessApiClient {
 
     private let baseURL: URL
     private let apiClient: ApiClient
-    private let session: URLSession
 
     init(
         dataCenter: KetchDataCenter = .us,
-        apiClient: ApiClient = DefaultApiClient(),
-        session: URLSession = .shared
+        apiClient: ApiClient = DefaultApiClient()
     ) {
         self.baseURL = dataCenter.baseURL
         self.apiClient = apiClient
-        self.session = session
     }
 
     func getLocation() -> AnyPublisher<KetchSDK.LocationResponse, KetchError> {
@@ -140,7 +137,10 @@ final class HeadlessApiClient {
     }
 
     func invokeRights(organization: String, config: KetchSDK.InvokeRightConfig) -> AnyPublisher<Void, KetchError> {
-        invokeRight(request: .init(organizationCode: organization, config: config))
+        guard let rightCode = config.rightCode, !rightCode.isEmpty else {
+            return Fail(error: KetchError.requestError).eraseToAnyPublisher()
+        }
+        return invokeRight(request: .init(organizationCode: organization, config: config))
     }
 
     func getPreferenceQRUrl(request: KetchSDK.PreferenceQRRequest) -> URL? {
@@ -225,20 +225,10 @@ final class HeadlessApiClient {
         guard let url = buildURL(path: path) else {
             return Fail(error: KetchError.requestError).eraseToAnyPublisher()
         }
-        var urlRequest = URLRequest(url: url)
-        urlRequest.httpMethod = "POST"
-        urlRequest.httpBody = body
-        applyJSONHeaders(&urlRequest)
-
-        return session.dataTaskPublisher(for: urlRequest)
-            .tryMap { output -> Void in
-                if let http = output.response as? HTTPURLResponse,
-                   !(200..<300).contains(http.statusCode) {
-                    throw URLError(.badServerResponse)
-                }
-                return ()
-            }
-            .mapError(KetchError.init)
+        let request = ApiRequest(endPoint: EndPoint(url: url), method: .post, body: body)
+        return apiClient.execute(request: request)
+            .map { _ in () }
+            .mapError { KetchError(with: $0) }
             .eraseToAnyPublisher()
     }
 
@@ -250,18 +240,9 @@ final class HeadlessApiClient {
         guard let url = buildURL(path: path) else {
             return Fail(error: KetchError.requestError).eraseToAnyPublisher()
         }
-        var urlRequest = URLRequest(url: url)
-        urlRequest.httpMethod = "POST"
-        urlRequest.httpBody = body
-        applyJSONHeaders(&urlRequest)
-
-        return session.dataTaskPublisher(for: urlRequest)
-            .tryMap { output -> ConsentStatus in
-                let data = output.data
-                if let http = output.response as? HTTPURLResponse,
-                   !(200..<300).contains(http.statusCode) {
-                    throw URLError(.badServerResponse)
-                }
+        let request = ApiRequest(endPoint: EndPoint(url: url), method: .post, body: body)
+        return apiClient.execute(request: request)
+            .map { data -> ConsentStatus in
                 if data.isEmpty || String(data: data, encoding: .utf8) == "null" {
                     return Self.emptyConsentStatus(for: config)
                 }
@@ -271,7 +252,7 @@ final class HeadlessApiClient {
                 }
                 return Self.emptyConsentStatus(for: config)
             }
-            .mapError(KetchError.init)
+            .mapError { KetchError(with: $0) }
             .eraseToAnyPublisher()
     }
 
@@ -283,25 +264,16 @@ final class HeadlessApiClient {
         guard let url = buildURL(path: path) else {
             return Fail(error: KetchError.requestError).eraseToAnyPublisher()
         }
-        var urlRequest = URLRequest(url: url)
-        urlRequest.httpMethod = "POST"
-        urlRequest.httpBody = body
-        applyJSONHeaders(&urlRequest)
-
-        return session.dataTaskPublisher(for: urlRequest)
-            .tryMap { output -> ConsentStatus in
-                let data = output.data
-                if let http = output.response as? HTTPURLResponse,
-                   !(200..<300).contains(http.statusCode) {
-                    throw URLError(.badServerResponse)
-                }
+        let request = ApiRequest(endPoint: EndPoint(url: url), method: .post, body: body)
+        return apiClient.execute(request: request)
+            .map { data -> ConsentStatus in
                 if let decoded = try? JSONDecoder().decode(ConsentStatus.self, from: data),
                    Self.hasUsableConsentFields(decoded) {
                     return Self.mergingProtocols(from: decoded, fallback: fallback)
                 }
                 return Self.consentStatus(from: fallback)
             }
-            .mapError(KetchError.init)
+            .mapError { KetchError(with: $0) }
             .eraseToAnyPublisher()
     }
 
@@ -316,17 +288,6 @@ final class HeadlessApiClient {
             components.queryItems = queryItems
         }
         return components.url
-    }
-
-    private func applyJSONHeaders(_ request: inout URLRequest) {
-        request.setValue(
-            ApiRequest.HeaderValue.applicationJson,
-            forHTTPHeaderField: ApiRequest.HeaderField.accept
-        )
-        request.setValue(
-            ApiRequest.HeaderValue.contentTypeJson,
-            forHTTPHeaderField: ApiRequest.HeaderField.contentType
-        )
     }
 
     private static func hasUsableConsentFields(_ status: ConsentStatus) -> Bool {

--- a/Sources/KetchSDK/Core/Ketch.swift
+++ b/Sources/KetchSDK/Core/Ketch.swift
@@ -31,8 +31,20 @@ public final class Ketch: ObservableObject {
     let propertyCode: String
     let environmentCode: String
     let identities: [Identity]
+    public let dataCenter: KetchDataCenter
+    private let apiRequest: KetchApiRequest
+    private let userDefaults: UserDefaults
     private let nativeStorage: NativeStorage
     private var plugins = Set<PolicyPlugin>()
+
+    // Headless getFullConfiguration() cache — avoids re-fetching when the config URL path is unchanged
+    private var cachedConfig: KetchSDK.Configuration?
+    private var cachedConfigKey: String?
+
+    // Headless getLocation() cache — GET /ip takes no path params, so it never needs invalidation
+    private var cachedLocation: KetchSDK.LocationResponse?
+
+    private let cacheLock = NSLock()
 
     private var configurationSubject = CurrentValueSubject<KetchSDK.Configuration?, KetchSDK.KetchError>(nil)
     private var localizedStringsSubject = CurrentValueSubject<KetchSDK.LocalizedStrings?, KetchSDK.KetchError>(nil)
@@ -51,12 +63,17 @@ public final class Ketch: ObservableObject {
         propertyCode: String,
         environmentCode: String,
         identities: [Identity],
-        userDefaults: UserDefaults = .standard
+        dataCenter: KetchDataCenter = .us,
+        userDefaults: UserDefaults = .standard,
+        apiClient: ApiClient = DefaultApiClient()
     ) {
         self.organizationCode = organizationCode
         self.propertyCode = propertyCode
         self.environmentCode = environmentCode
         self.identities = identities
+        self.dataCenter = dataCenter
+        self.apiRequest = KetchApiRequest(dataCenter: dataCenter, apiClient: apiClient)
+        self.userDefaults = userDefaults
         self.nativeStorage = NativeStorage(userDefaults: userDefaults)
 
         configurationSubject
@@ -99,7 +116,7 @@ public final class Ketch: ObservableObject {
     }
 
     public func loadConfiguration() {
-        KetchApiRequest()
+        apiRequest
             .fetchConfig(organization: organizationCode, property: propertyCode)
             .sink { result in
                 if case .failure(let error) = result {
@@ -109,7 +126,7 @@ public final class Ketch: ObservableObject {
                 self.configurationSubject.send(configuration)
             }
             .store(in: &subscriptions)
-        KetchApiRequest()
+        apiRequest
             .fetchLocalizedStrings()
             .sink { result in
                 if case .failure(let error) = result {
@@ -124,7 +141,7 @@ public final class Ketch: ObservableObject {
     public func loadConfiguration(
         jurisdiction: String
     ) {
-        KetchApiRequest()
+        apiRequest
             .fetchConfig(
                 organization: organizationCode,
                 property: propertyCode,
@@ -141,7 +158,7 @@ public final class Ketch: ObservableObject {
                 self.configurationSubject.send(configuration)
             }
             .store(in: &subscriptions)
-        KetchApiRequest()
+        apiRequest
             .fetchLocalizedStrings(languageCode:String(Locale.preferredLanguages[0].prefix(2)))
             .sink { result in
                 if case .failure(let error) = result {
@@ -164,7 +181,7 @@ public final class Ketch: ObservableObject {
             uniqueKeysWithValues: identities.map { ($0.key, $0.value) }
         )
 
-        return KetchApiRequest()
+        return apiRequest
             .invokeRights(
                 organization: organizationCode,
                 config: .init(
@@ -224,21 +241,22 @@ public final class Ketch: ObservableObject {
                 })
         else { return }
 
-        let identities = [String: String](
-            uniqueKeysWithValues: identities.map { ($0.key, $0.value) }
-        )
-
-        KetchApiRequest()
-            .getConsent(
-                config: .init(
-                    organizationCode: organizationCode,
-                    propertyCode: propertyCode,
-                    environmentCode: environmentCode,
-                    jurisdictionCode: jurisdictionCode,
-                    identities: identities,
-                    purposes: purposes
-                )
+        loadConsent(
+            consentConfig: .init(
+                organizationCode: organizationCode,
+                propertyCode: propertyCode,
+                environmentCode: environmentCode,
+                jurisdictionCode: jurisdictionCode,
+                identities: identityMap(),
+                purposes: purposes
             )
+        )
+    }
+
+    /// Fetches consent from the CDN without requiring WebView-loaded configuration.
+    public func loadConsent(consentConfig: KetchSDK.ConsentConfig) {
+        apiRequest
+            .getConsent(config: consentConfig)
             .sink { result in
                 if case .failure(let error) = result {
                     self.consentSubject.send(completion: .failure(error))
@@ -249,6 +267,10 @@ public final class Ketch: ObservableObject {
             .store(in: &subscriptions)
     }
 
+    private func identityMap() -> [String: String] {
+        [String: String](uniqueKeysWithValues: identities.map { ($0.key, $0.value) })
+    }
+
     public func updateConsent(
         purposes: [String: KetchSDK.ConsentUpdate.PurposeAllowedLegalBasis]?,
         vendors: [String]?,
@@ -256,17 +278,13 @@ public final class Ketch: ObservableObject {
     ) {
         guard let jurisdictionCode = configurationSubject.value?.jurisdiction?.code else { return }
 
-        let identities = [String: String](
-            uniqueKeysWithValues: identities.map { ($0.key, $0.value) }
-        )
-        
-        return KetchApiRequest()
-            .updateConsent(
+        return apiRequest
+            .setConsent(
                 update: .init(
                     organizationCode: organizationCode,
                     propertyCode: propertyCode,
                     environmentCode: environmentCode,
-                    identities: identities,
+                    identities: identityMap(),
                     jurisdictionCode: jurisdictionCode,
                     migrationOption: .migrateDefault,
                     purposes: purposes ?? [:],
@@ -278,19 +296,171 @@ public final class Ketch: ObservableObject {
                 if case .failure(let error) = result {
                     print(error)
                 }
-            } receiveValue: {
-                let purposesUpdate = purposes?.reduce(into: [String: Bool](), { result, purpose in
-                    result[purpose.key] = purpose.value.allowed
-                })
-                let consentUpdate = KetchSDK.ConsentStatus(
-                    purposes: purposesUpdate ?? [:],
-                    vendors: vendors,
-                    protocols: protocols
-                )
-
-                self.consentSubject.send(consentUpdate)
+            } receiveValue: { consentStatus in
+                self.consentSubject.send(consentStatus)
             }
             .store(in: &subscriptions)
+    }
+}
+
+// MARK: - Headless API (web/v3, pre-WebView)
+extension Ketch {
+    /// GeoIP location (`GET /ip`). Cached on this instance — `/ip` takes no path params, so the
+    /// cache never invalidates.
+    private func getLocation(
+        completion: @escaping (Result<KetchSDK.LocationResponse, KetchSDK.KetchError>) -> Void
+    ) {
+        cacheLock.lock()
+        if let cachedLocation {
+            cacheLock.unlock()
+            completion(.success(cachedLocation))
+            return
+        }
+        cacheLock.unlock()
+
+        apiRequest.getLocation()
+            .sink { if case .failure(let error) = $0 { completion(.failure(error)) } }
+            receiveValue: { location in
+                self.cacheLock.lock()
+                self.cachedLocation = location
+                self.cacheLock.unlock()
+                completion(.success(location))
+            }
+            .store(in: &subscriptions)
+    }
+
+    /// Combined ISO region code (e.g. "US-CA") from GeoIP. Backed by the same cache as [getLocation].
+    public func getRegion(
+        completion: @escaping (Result<String?, KetchSDK.KetchError>) -> Void
+    ) {
+        getLocation { result in
+            completion(result.map { $0.location?.toRegionCode() })
+        }
+    }
+
+    public func getBootstrapConfiguration(
+        completion: @escaping (Result<KetchSDK.Configuration, KetchSDK.KetchError>) -> Void
+    ) {
+        apiRequest.getBootstrapConfiguration(organization: organizationCode, property: propertyCode)
+            .sink { if case .failure(let error) = $0 { completion(.failure(error)) } }
+            receiveValue: { completion(.success($0)) }
+            .store(in: &subscriptions)
+    }
+
+    /// Full config with optional env/jurisdiction/language and hash query param.
+    ///
+    /// Cached on this instance, keyed on the request's URL-path-affecting fields. A cache hit
+    /// skips the network call entirely.
+    public func getFullConfiguration(
+        request: KetchSDK.FullConfigurationRequest,
+        completion: @escaping (Result<KetchSDK.Configuration, KetchSDK.KetchError>) -> Void
+    ) {
+        let key = Self.buildConfigCacheKey(for: request)
+        cacheLock.lock()
+        if cachedConfigKey == key, let cachedConfig {
+            cacheLock.unlock()
+            completion(.success(cachedConfig))
+            return
+        }
+        cacheLock.unlock()
+
+        apiRequest.getFullConfiguration(request: request)
+            .sink { if case .failure(let error) = $0 { completion(.failure(error)) } }
+            receiveValue: { configuration in
+                self.cacheLock.lock()
+                self.cachedConfig = configuration
+                self.cachedConfigKey = key
+                self.cacheLock.unlock()
+                completion(.success(configuration))
+            }
+            .store(in: &subscriptions)
+    }
+
+    /// Resolved jurisdiction code for this instance's current org/property/environment, e.g. from
+    /// a `jurisdiction` `ExperienceOption`. Backed by the same cache as [getFullConfiguration].
+    public func getJurisdiction(
+        completion: @escaping (Result<String?, KetchSDK.KetchError>) -> Void
+    ) {
+        getFullConfiguration(request: buildJurisdictionConfigRequest()) { result in
+            completion(result.map { $0.jurisdictionCode() })
+        }
+    }
+
+    private func buildJurisdictionConfigRequest() -> KetchSDK.FullConfigurationRequest {
+        .init(
+            organizationCode: organizationCode,
+            propertyCode: propertyCode,
+            environmentCode: environmentCode
+        )
+    }
+
+    // Cache key for getFullConfiguration() — mirrors HeadlessApiClient's path- and query-building
+    // exactly via configPathSegment()/configQueryItems(), so requests that hit the same URL
+    // always share a key and requests that hit different URLs never collide.
+    private static func buildConfigCacheKey(for request: KetchSDK.FullConfigurationRequest) -> String {
+        let segment = request.configPathSegment()
+        let query = request.configQueryItems().map { "\($0.name)=\($0.value ?? "")" }
+        return ([
+            request.organizationCode,
+            request.propertyCode,
+            segment?.env ?? "",
+            segment?.jurisdiction ?? "",
+            segment?.language ?? ""
+        ] + query).joined(separator: "|")
+    }
+
+    public func getConsent(
+        consentConfig: KetchSDK.ConsentConfig,
+        completion: @escaping (Result<KetchSDK.ConsentStatus, KetchSDK.KetchError>) -> Void
+    ) {
+        apiRequest.getConsent(config: consentConfig)
+            .sink { if case .failure(let error) = $0 { completion(.failure(error)) } }
+            receiveValue: { completion(.success($0)) }
+            .store(in: &subscriptions)
+    }
+
+    public func setConsent(
+        consentUpdate: KetchSDK.ConsentUpdate,
+        completion: @escaping (Result<KetchSDK.ConsentStatus, KetchSDK.KetchError>) -> Void
+    ) {
+        apiRequest.setConsent(update: consentUpdate)
+            .sink { if case .failure(let error) = $0 { completion(.failure(error)) } }
+            receiveValue: { completion(.success($0)) }
+            .store(in: &subscriptions)
+    }
+
+    public func invokeRight(
+        request: KetchSDK.InvokeRightRequest,
+        completion: @escaping (Result<Void, KetchSDK.KetchError>) -> Void
+    ) {
+        apiRequest.invokeRight(request: request)
+            .sink { if case .failure(let error) = $0 { completion(.failure(error)) } }
+            receiveValue: { completion(.success(())) }
+            .store(in: &subscriptions)
+    }
+
+    public func getSubscriptions(
+        request: KetchSDK.SubscriptionsRequest,
+        completion: @escaping (Result<KetchSDK.SubscriptionsResponse, KetchSDK.KetchError>) -> Void
+    ) {
+        apiRequest.getSubscriptions(request: request)
+            .sink { if case .failure(let error) = $0 { completion(.failure(error)) } }
+            receiveValue: { completion(.success($0)) }
+            .store(in: &subscriptions)
+    }
+
+    public func setSubscriptions(
+        request: KetchSDK.SubscriptionsRequest,
+        completion: @escaping (Result<Void, KetchSDK.KetchError>) -> Void
+    ) {
+        apiRequest.setSubscriptions(request: request)
+            .sink { if case .failure(let error) = $0 { completion(.failure(error)) } }
+            receiveValue: { completion(.success(())) }
+            .store(in: &subscriptions)
+    }
+
+    public func getPreferenceQRUrl(request: KetchSDK.PreferenceQRRequest) -> URL? {
+        apiRequest.getPreferenceQRUrl(request: request)
     }
 }
 
@@ -314,8 +484,8 @@ extension Ketch {
         property: String,
         completion: @escaping (Result<KetchSDK.Configuration, KetchSDK.KetchError>
     ) -> Void) {
-        KetchApiRequest()
-            .fetchConfig(organization: organization, property: organization)
+        apiRequest
+            .fetchConfig(organization: organization, property: property)
             .sink { result in
                 if case .failure(let error) = result {
                     completion(.failure(error))
@@ -330,32 +500,19 @@ extension Ketch {
         consentConfig: KetchSDK.ConsentConfig,
         completion: @escaping (Result<KetchSDK.ConsentStatus, KetchSDK.KetchError>) -> Void
     ) {
-        KetchApiRequest()
-            .getConsent(config: consentConfig)
-            .sink { result in
-                if case .failure(let error) = result {
-                    completion(.failure(error))
-                }
-            } receiveValue: { consentStatus in
-                completion(.success(consentStatus))
-            }
-            .store(in: &subscriptions)
+        getConsent(consentConfig: consentConfig, completion: completion)
     }
 
     public func fetchSetConsent(
         consentUpdate: KetchSDK.ConsentUpdate,
         completion: @escaping (Result<Void, KetchSDK.KetchError>) -> Void
     ) {
-        KetchApiRequest()
-            .updateConsent(update: consentUpdate)
-            .sink { result in
-                if case .failure(let error) = result {
-                    completion(.failure(error))
-                }
-            } receiveValue: {
-                completion(.success(()))
+        setConsent(consentUpdate: consentUpdate) { result in
+            switch result {
+            case .success: completion(.success(()))
+            case .failure(let error): completion(.failure(error))
             }
-            .store(in: &subscriptions)
+        }
     }
 
     public func fetchInvokeRights(
@@ -363,7 +520,7 @@ extension Ketch {
         config: KetchSDK.InvokeRightConfig,
         completion: @escaping (Result<Void, KetchSDK.KetchError>) -> Void
     ) {
-        KetchApiRequest()
+        apiRequest
             .invokeRights(
                 organization: organization,
                 config: config

--- a/Sources/KetchSDK/Core/Ketch.swift
+++ b/Sources/KetchSDK/Core/Ketch.swift
@@ -44,6 +44,12 @@ public final class Ketch: ObservableObject {
     // Headless getLocation() cache — GET /ip takes no path params, so it never needs invalidation
     private var cachedLocation: KetchSDK.LocationResponse?
 
+    // Local overrides for getRegion()/getJurisdiction(), set via setRegion()/setJurisdiction().
+    // Take precedence over the server-resolved values; also fed into buildJurisdictionConfigRequest()
+    // so a jurisdiction override is reflected in the request path, not just the getter's return value.
+    private var region: String?
+    private var jurisdiction: String?
+
     private let cacheLock = NSLock()
 
     private var configurationSubject = CurrentValueSubject<KetchSDK.Configuration?, KetchSDK.KetchError>(nil)
@@ -329,13 +335,27 @@ extension Ketch {
             .store(in: &subscriptions)
     }
 
-    /// Combined ISO region code (e.g. "US-CA") from GeoIP. Backed by the same cache as [getLocation].
+    /// Combined ISO region code (e.g. "US-CA"). Returns the value from `setRegion` if one is set
+    /// on this instance; otherwise falls back to GeoIP (`GET /ip`), cached on this instance via
+    /// [getLocation].
     public func getRegion(
         completion: @escaping (Result<String?, KetchSDK.KetchError>) -> Void
     ) {
+        if let region {
+            completion(.success(region))
+            return
+        }
         getLocation { result in
             completion(result.map { $0.location?.toRegionCode() })
         }
+    }
+
+    /// Overrides the value returned by `getRegion()`, bypassing the GeoIP round-trip. Also feeds
+    /// `getJurisdiction()`'s config request, so pass `nil` to clear the override and resume
+    /// resolving both from the server.
+    public func setRegion(_ region: String?) {
+        self.region = region
+        clearConfigCache()
     }
 
     public func getBootstrapConfiguration(
@@ -376,22 +396,44 @@ extension Ketch {
             .store(in: &subscriptions)
     }
 
-    /// Resolved jurisdiction code for this instance's current org/property/environment, e.g. from
-    /// a `jurisdiction` `ExperienceOption`. Backed by the same cache as [getFullConfiguration].
+    /// Resolved jurisdiction code for this instance's current org/property/environment. Returns
+    /// the value from `setJurisdiction` if one is set on this instance; otherwise falls back to
+    /// the server-resolved code from [getFullConfiguration], which the same cache backs.
     public func getJurisdiction(
         completion: @escaping (Result<String?, KetchSDK.KetchError>) -> Void
     ) {
+        if let jurisdiction {
+            completion(.success(jurisdiction))
+            return
+        }
         getFullConfiguration(request: buildJurisdictionConfigRequest()) { result in
             completion(result.map { $0.jurisdictionCode() })
         }
+    }
+
+    /// Overrides the value returned by `getJurisdiction()`, bypassing the server round-trip and
+    /// invalidating the [getFullConfiguration] cache, since jurisdiction affects the config URL
+    /// path. Pass `nil` to clear the override and resume resolving from the server.
+    public func setJurisdiction(_ jurisdiction: String?) {
+        self.jurisdiction = jurisdiction
+        clearConfigCache()
     }
 
     private func buildJurisdictionConfigRequest() -> KetchSDK.FullConfigurationRequest {
         .init(
             organizationCode: organizationCode,
             propertyCode: propertyCode,
-            environmentCode: environmentCode
+            environmentCode: environmentCode,
+            jurisdictionCode: jurisdiction,
+            regionCode: region
         )
+    }
+
+    private func clearConfigCache() {
+        cacheLock.lock()
+        cachedConfig = nil
+        cachedConfigKey = nil
+        cacheLock.unlock()
     }
 
     // Cache key for getFullConfiguration() — mirrors HeadlessApiClient's path- and query-building

--- a/Sources/KetchSDK/Core/KetchApiRequest.swift
+++ b/Sources/KetchSDK/Core/KetchApiRequest.swift
@@ -6,7 +6,7 @@
 import Foundation
 import Combine
 
-/// Request processor for available platform API
+/// Request processor for Ketch headless (web/v3) API.
 class KetchApiRequest {
     typealias KetchError = KetchSDK.KetchError
     typealias Configuration = KetchSDK.Configuration
@@ -17,13 +17,15 @@ class KetchApiRequest {
     typealias Vendors = KetchSDK.Vendors
     typealias LocalizedStrings = KetchSDK.LocalizedStrings
 
+    private let headless: HeadlessApiClient
     private let apiClient: ApiClient
 
-    init(apiClient: ApiClient = DefaultApiClient()) {
+    init(dataCenter: KetchDataCenter = .us, apiClient: ApiClient = DefaultApiClient()) {
         self.apiClient = apiClient
+        self.headless = HeadlessApiClient(dataCenter: dataCenter, apiClient: apiClient)
     }
-    
-    func fetchLocalizedStrings(languageCode:String = String(Locale.preferredLanguages[0].prefix(2))) -> AnyPublisher<LocalizedStrings, KetchError> {
+
+    func fetchLocalizedStrings(languageCode: String = String(Locale.preferredLanguages[0].prefix(2))) -> AnyPublisher<LocalizedStrings, KetchError> {
         apiClient.execute(
             request: ApiRequest(
                 endPoint: .localizedStrings(languageCode: languageCode)
@@ -34,15 +36,20 @@ class KetchApiRequest {
         .eraseToAnyPublisher()
     }
 
+    func getLocation() -> AnyPublisher<KetchSDK.LocationResponse, KetchError> {
+        headless.getLocation()
+    }
+
+    func getBootstrapConfiguration(organization: String, property: String) -> AnyPublisher<Configuration, KetchError> {
+        headless.getBootstrapConfiguration(organization: organization, property: property)
+    }
+
+    func getFullConfiguration(request: KetchSDK.FullConfigurationRequest) -> AnyPublisher<Configuration, KetchError> {
+        headless.getFullConfiguration(request: request)
+    }
+
     func fetchConfig(organization: String, property: String) -> AnyPublisher<Configuration, KetchError> {
-        apiClient.execute(
-            request: ApiRequest(
-                endPoint: .config(organization: organization, property: property)
-            )
-        )
-        .decode(type: Configuration.self, decoder: JSONDecoder())
-        .mapError(KetchError.init)
-        .eraseToAnyPublisher()
+        headless.fetchConfig(organization: organization, property: property)
     }
 
     func fetchConfig(
@@ -53,72 +60,48 @@ class KetchApiRequest {
         jurisdiction: String,
         language: String
     ) -> AnyPublisher<Configuration, KetchError> {
-        apiClient.execute(
-            request: ApiRequest(
-                endPoint: .fullConfig(
-                    organization: organization,
-                    property: property,
-                    environment: environment,
-                    hash: hash,
-                    jurisdiction: jurisdiction,
-                    language: language
-                )
-            )
+        headless.fetchConfig(
+            organization: organization,
+            property: property,
+            environment: environment,
+            hash: String(hash),
+            jurisdiction: jurisdiction,
+            language: language
         )
-        .decode(type: Configuration.self, decoder: JSONDecoder())
-        .mapError(KetchError.init)
-        .eraseToAnyPublisher()
     }
 
     func getConsent(config: ConsentConfig) -> AnyPublisher<ConsentStatus, KetchError> {
-        apiClient.execute(
-            request: ApiRequest(
-                endPoint: .getConsent(organization: config.organizationCode),
-                method: .post,
-                body: try? JSONEncoder().encode(config)
-            )
-        )
-        .decode(type: ConsentStatus.self, decoder: JSONDecoder())
-        .mapError(KetchError.init)
-        .eraseToAnyPublisher()
+        headless.getConsent(config: config)
     }
 
-    func updateConsent(update: ConsentUpdate) -> AnyPublisher<Void, KetchError> {
-        apiClient.execute(
-            request: ApiRequest(
-                endPoint: .updateConsent(organization: update.organizationCode),
-                method: .post,
-                body: try? JSONEncoder().encode(update)
-            )
-        )
-        .map { _ in }
-        .mapError(KetchError.init)
-        .eraseToAnyPublisher()
+    func setConsent(update: ConsentUpdate) -> AnyPublisher<ConsentStatus, KetchError> {
+        headless.setConsent(update: update)
     }
 
     func invokeRights(organization: String, config: InvokeRightConfig) -> AnyPublisher<Void, KetchError> {
-        apiClient.execute(
-            request: ApiRequest(
-                endPoint: .invokeRights(organization: organization),
-                method: .post,
-                body: try? JSONEncoder().encode(config)
-            )
-        )
-        .map { _ in }
-        .mapError(KetchError.init)
-        .eraseToAnyPublisher()
+        headless.invokeRights(organization: organization, config: config)
+    }
+
+    func invokeRight(request: KetchSDK.InvokeRightRequest) -> AnyPublisher<Void, KetchError> {
+        headless.invokeRight(request: request)
+    }
+
+    func getSubscriptions(
+        request: KetchSDK.SubscriptionsRequest
+    ) -> AnyPublisher<KetchSDK.SubscriptionsResponse, KetchError> {
+        headless.getSubscriptions(request: request)
+    }
+
+    func setSubscriptions(request: KetchSDK.SubscriptionsRequest) -> AnyPublisher<Void, KetchError> {
+        headless.setSubscriptions(request: request)
+    }
+
+    func getPreferenceQRUrl(request: KetchSDK.PreferenceQRRequest) -> URL? {
+        headless.getPreferenceQRUrl(request: request)
     }
 
     func getVendors() -> AnyPublisher<Vendors, KetchError> {
-        apiClient.execute(
-            request: ApiRequest(
-                endPoint: .getVendors(),
-                method: .get
-            )
-        )
-        .decode(type: Vendors.self, decoder: JSONDecoder())
-        .mapError(KetchError.init)
-        .eraseToAnyPublisher()
+        headless.getVendors()
     }
 }
 

--- a/Sources/KetchSDK/Core/KetchDataCenter.swift
+++ b/Sources/KetchSDK/Core/KetchDataCenter.swift
@@ -1,0 +1,24 @@
+//
+//  KetchDataCenter.swift
+//  KetchSDK
+//
+
+import Foundation
+
+/// Ketch CDN region for headless and WebView API calls.
+public enum KetchDataCenter: String, Codable, Sendable {
+    case us
+    case eu
+    case uat
+
+    /// web/v3 base URL for this region (matches Flutter / React Native maps).
+    public var baseURL: URL {
+        URL(string: Self.baseURLString[self]!)!
+    }
+
+    private static let baseURLString: [KetchDataCenter: String] = [
+        .us: "https://global.ketchcdn.com/web/v3",
+        .eu: "https://eu.ketchcdn.com/web/v3",
+        .uat: "https://dev.ketchcdn.com/web/v3",
+    ]
+}

--- a/Sources/KetchSDK/Core/KetchSDK.swift
+++ b/Sources/KetchSDK/Core/KetchSDK.swift
@@ -4,6 +4,7 @@
 //
 
 import Combine
+import Foundation
 
 public enum KetchSDK {
     /// Instantiation of Ketch core class
@@ -12,129 +13,207 @@ public enum KetchSDK {
     ///   - propertyCode: Property defined in the platform side.
     ///   - environmentCode: Environment defined in the platform side.
     ///   - identities: Identifiers of current instance of app. Possible types defined in the platform side. For iOS it is usually "idfa" (AdvertisementIdentifier)
+    ///   - dataCenter: CDN region for headless API calls (defaults to US).
     /// - Returns: Ketch instance.
     public static func create(
         organizationCode: String,
         propertyCode: String,
         environmentCode: String,
-        identities: [Ketch.Identity]
+        identities: [Ketch.Identity],
+        dataCenter: KetchDataCenter = .us
     ) -> Ketch {
         Ketch(
             organizationCode: organizationCode,
             propertyCode: propertyCode,
             environmentCode: environmentCode,
-            identities: identities
+            identities: identities,
+            dataCenter: dataCenter
         )
     }
 }
 
+// MARK: - Headless API (static, web/v3)
+
+extension KetchSDK {
+    /// Combined ISO region code (e.g. "US-CA") from GeoIP (`GET /ip`).
+    public static func getRegion(
+        dataCenter: KetchDataCenter = .us
+    ) -> AnyPublisher<String?, KetchError> {
+        KetchApiRequest(dataCenter: dataCenter).getLocation()
+            .map { $0.location?.toRegionCode() }
+            .eraseToAnyPublisher()
+    }
+
+    /// Minimal config (`GET .../boot.json`).
+    public static func getBootstrapConfiguration(
+        organization: String,
+        property: String,
+        dataCenter: KetchDataCenter = .us
+    ) -> AnyPublisher<Configuration, KetchError> {
+        KetchApiRequest(dataCenter: dataCenter)
+            .getBootstrapConfiguration(organization: organization, property: property)
+    }
+
+    /// Full config with optional env / jurisdiction / language and hash query param.
+    public static func getFullConfiguration(
+        request: FullConfigurationRequest,
+        dataCenter: KetchDataCenter = .us
+    ) -> AnyPublisher<Configuration, KetchError> {
+        KetchApiRequest(dataCenter: dataCenter).getFullConfiguration(request: request)
+    }
+
+    /// Resolved jurisdiction code from full config (`GET .../config.json`).
+    public static func getJurisdiction(
+        request: FullConfigurationRequest,
+        dataCenter: KetchDataCenter = .us
+    ) -> AnyPublisher<String?, KetchError> {
+        KetchApiRequest(dataCenter: dataCenter).getFullConfiguration(request: request)
+            .map { $0.jurisdictionCode() }
+            .eraseToAnyPublisher()
+    }
+
+    /// Server consent including `protocols` (`POST .../consent/{org}/get`).
+    public static func getConsent(
+        config: ConsentConfig,
+        dataCenter: KetchDataCenter = .us
+    ) -> AnyPublisher<ConsentStatus, KetchError> {
+        KetchApiRequest(dataCenter: dataCenter).getConsent(config: config)
+    }
+
+    /// Updates consent; returns server response with computed `protocols`. Does not send `protocols` in the request body.
+    public static func setConsent(
+        update: ConsentUpdate,
+        dataCenter: KetchDataCenter = .us
+    ) -> AnyPublisher<ConsentStatus, KetchError> {
+        KetchApiRequest(dataCenter: dataCenter).setConsent(update: headlessUpdate(from: update))
+    }
+
+    private static func headlessUpdate(from update: ConsentUpdate) -> ConsentUpdate {
+        ConsentUpdate(
+            organizationCode: update.organizationCode,
+            propertyCode: update.propertyCode,
+            environmentCode: update.environmentCode,
+            identities: update.identities,
+            jurisdictionCode: update.jurisdictionCode,
+            migrationOption: update.migrationOption,
+            purposes: update.purposes,
+            vendors: update.vendors,
+            protocols: update.protocols
+        )
+    }
+
+    /// Invokes a data subject right (`POST .../rights/{org}/invoke`).
+    public static func invokeRight(
+        request: InvokeRightRequest,
+        dataCenter: KetchDataCenter = .us
+    ) -> AnyPublisher<Void, KetchError> {
+        KetchApiRequest(dataCenter: dataCenter).invokeRight(request: request)
+    }
+
+    /// Gets subscription topics/controls (`POST .../subscriptions/{org}/get`).
+    public static func getSubscriptions(
+        request: SubscriptionsRequest,
+        dataCenter: KetchDataCenter = .us
+    ) -> AnyPublisher<SubscriptionsResponse, KetchError> {
+        KetchApiRequest(dataCenter: dataCenter).getSubscriptions(request: request)
+    }
+
+    /// Updates subscription topics/controls (`POST .../subscriptions/{org}/update`).
+    public static func setSubscriptions(
+        request: SubscriptionsRequest,
+        dataCenter: KetchDataCenter = .us
+    ) -> AnyPublisher<Void, KetchError> {
+        KetchApiRequest(dataCenter: dataCenter).setSubscriptions(request: request)
+    }
+
+    public static func getPreferenceQRUrl(
+        request: PreferenceQRRequest,
+        dataCenter: KetchDataCenter = .us
+    ) -> URL? {
+        HeadlessApiClient(dataCenter: dataCenter).getPreferenceQRUrl(request: request)
+    }
+}
+
+// MARK: - Legacy static publishers
+
 extension KetchSDK {
     /// Retrieves full organization configuration data.
-    /// - Parameters:
-    ///   - organization: organization code
-    ///   - property: property code
-    /// - Returns: Publisher of organization configuration request result.
-    public func config(
+    public static func config(
         organization: String,
-        property: String
+        property: String,
+        dataCenter: KetchDataCenter = .us
     ) -> AnyPublisher<Configuration, KetchError> {
-        KetchApiRequest()
+        KetchApiRequest(dataCenter: dataCenter)
             .fetchConfig(organization: organization, property: property)
-            .eraseToAnyPublisher()
     }
 
-    /// Retrieves currently set consent status.
-    /// - Parameters:
-    ///   - organizationCode: organization code
-    ///   - propertyCode: property code
-    ///   - environmentCode: environment code
-    ///   - jurisdictionCode: jurisdiction code
-    ///   - identities: map of identity code and value
-    ///   - purposes: map of purpose code and PurposeLegalBasis
-    /// - Returns: Publisher of set consent request result.
-    public func getConsent(
+    /// Retrieves currently set consent status from the CDN.
+    public static func getConsent(
         organizationCode: String,
         propertyCode: String,
         environmentCode: String,
         jurisdictionCode: String,
-        identities: [String : String],
-        purposes: [String : ConsentConfig.PurposeLegalBasis]
+        identities: [String: String],
+        purposes: [String: ConsentConfig.PurposeLegalBasis],
+        dataCenter: KetchDataCenter = .us
     ) -> AnyPublisher<ConsentStatus, KetchError> {
-        KetchApiRequest()
-            .getConsent(
-                config: ConsentConfig(
-                    organizationCode: organizationCode,
-                    propertyCode: propertyCode,
-                    environmentCode: environmentCode,
-                    jurisdictionCode: jurisdictionCode,
-                    identities: identities,
-                    purposes: purposes
-                )
-            )
-            .eraseToAnyPublisher()
+        getConsent(
+            config: ConsentConfig(
+                organizationCode: organizationCode,
+                propertyCode: propertyCode,
+                environmentCode: environmentCode,
+                jurisdictionCode: jurisdictionCode,
+                identities: identities,
+                purposes: purposes
+            ),
+            dataCenter: dataCenter
+        )
     }
 
-    /// Sends a request for updating consent status
-    /// - Parameters:
-    ///   - organizationCode: organization code
-    ///   - propertyCode: property code
-    ///   - environmentCode: environment code
-    ///   - identities: map of identity code and value
-    ///   - jurisdictionCode: jurisdiction code
-    ///   - migrationOption: migration option.
-    ///   - purposes: map of purpose code and PurposeLegalBasis
-    ///   - vendors: list of vendors
-    /// - Returns: Publisher of get consent request result.
-    public func setConsent(
+    /// Sends a request for updating consent status; completes when the CDN accepts the update.
+    public static func setConsent(
         organizationCode: String,
         propertyCode: String,
         environmentCode: String,
-        identities: [String : String],
+        identities: [String: String],
         jurisdictionCode: String,
         migrationOption: ConsentUpdate.MigrationOption,
-        purposes: [String : ConsentUpdate.PurposeAllowedLegalBasis],
+        purposes: [String: ConsentUpdate.PurposeAllowedLegalBasis],
         vendors: [String]?,
-        protocols: [String: String]?
+        protocols: [String: String]?,
+        dataCenter: KetchDataCenter = .us
     ) -> AnyPublisher<Void, KetchError> {
-        KetchApiRequest()
-            .updateConsent(
-                update: ConsentUpdate(
-                    organizationCode: organizationCode,
-                    propertyCode: propertyCode,
-                    environmentCode: environmentCode,
-                    identities: identities,
-                    jurisdictionCode: jurisdictionCode,
-                    migrationOption: migrationOption,
-                    purposes: purposes,
-                    vendors: vendors,
-                    protocols: protocols
-                )
-            )
-            .eraseToAnyPublisher()
+        setConsent(
+            update: ConsentUpdate(
+                organizationCode: organizationCode,
+                propertyCode: propertyCode,
+                environmentCode: environmentCode,
+                identities: identities,
+                jurisdictionCode: jurisdictionCode,
+                migrationOption: migrationOption,
+                purposes: purposes,
+                vendors: vendors,
+                protocols: protocols
+            ),
+            dataCenter: dataCenter
+        )
+        .map { _ in () }
+        .eraseToAnyPublisher()
     }
 
     /// Invokes the specified rights.
-    /// - Parameters:
-    ///   - organizationCode: organization code
-    ///   - propertyCode: property code
-    ///   - environmentCode: environment code
-    ///   - identities: jurisdiction code
-    ///   - invokedAt: the current time
-    ///   - jurisdictionCode: map of identity code and value
-    ///   - rightCode: right code
-    ///   - user: current user object
-    /// - Returns: Publisher of invoke rights request result.
-    public func invokeRights(
+    public static func invokeRights(
         organizationCode: String,
         propertyCode: String,
         environmentCode: String,
-        identities: [String : String],
+        identities: [String: String],
         invokedAt: Int?,
         jurisdictionCode: String,
         rightCode: String,
-        user: InvokeRightConfig.User
+        user: InvokeRightConfig.User,
+        dataCenter: KetchDataCenter = .us
     ) -> AnyPublisher<Void, KetchError> {
-        KetchApiRequest()
+        KetchApiRequest(dataCenter: dataCenter)
             .invokeRights(
                 organization: organizationCode,
                 config: InvokeRightConfig(
@@ -147,15 +226,13 @@ extension KetchSDK {
                     user: user
                 )
             )
-            .eraseToAnyPublisher()
     }
 
-    /// Retrieves list of consents vendors.
-    /// - Returns: Publisher of getVendors request result.
-    public func getVendors() -> AnyPublisher<Vendors, KetchError> {
-        KetchApiRequest()
-            .getVendors()
-            .eraseToAnyPublisher()
+    /// Retrieves list of consent vendors.
+    public static func getVendors(
+        dataCenter: KetchDataCenter = .us
+    ) -> AnyPublisher<Vendors, KetchError> {
+        KetchApiRequest(dataCenter: dataCenter).getVendors()
     }
 }
 
@@ -166,6 +243,7 @@ extension KetchSDK {
         case Close = "close"
         case CloseWithoutSettingConsent = "closeWithoutSettingConsent"
         case WillNotShow = "willNotShow"
+        case SetSubscriptions = "setSubscriptions"
         case None = "none"
     }
     

--- a/Sources/KetchSDK/UI/KetchUI.swift
+++ b/Sources/KetchSDK/UI/KetchUI.swift
@@ -68,7 +68,16 @@ public final class KetchUI: ObservableObject {
     
     private func preloadWebExperience() {
         preloadedPresentationItem = webExperience(onEvent: handle)
-        preloadedPresentationItem?.reload(options: options)
+        preloadedPresentationItem?.reload(options: experienceOptionsWithDataCenter(options))
+    }
+
+    private func experienceOptionsWithDataCenter(_ options: [ExperienceOption]) -> [ExperienceOption] {
+        guard !options.contains(where: { if case .ketchURL = $0 { return true }; return false }) else {
+            return options
+        }
+        var result = options
+        result.append(.ketchURL(ketch.dataCenter.baseURL.absoluteString))
+        return result
     }
     
     private func handle(webPresentationEvent: WebPresentationItem.Event) {
@@ -173,7 +182,7 @@ extension KetchUI {
             newOptions.append(option)
         }
         
-        preloadedPresentationItem?.reload(options: newOptions)
+        preloadedPresentationItem?.reload(options: experienceOptionsWithDataCenter(newOptions))
     }
     
     public func showExperience() {

--- a/Tests/KetchSDKTests/FullConfigurationRequestTests.swift
+++ b/Tests/KetchSDKTests/FullConfigurationRequestTests.swift
@@ -1,0 +1,173 @@
+import XCTest
+@testable import KetchSDK
+
+final class FullConfigurationRequestTests: XCTestCase {
+    func testConfigPathSegment_allPresentAndNonBlank_returnsSegment() {
+        let request = KetchSDK.FullConfigurationRequest(
+            organizationCode: "acme",
+            propertyCode: "prop",
+            environmentCode: "production",
+            jurisdictionCode: "us-ca",
+            languageCode: "en-US"
+        )
+        let segment = request.configPathSegment()
+        XCTAssertEqual(segment?.env, "production")
+        XCTAssertEqual(segment?.jurisdiction, "us-ca")
+        XCTAssertEqual(segment?.language, "en-US")
+    }
+
+    func testConfigPathSegment_nilField_returnsNil() {
+        let request = KetchSDK.FullConfigurationRequest(
+            organizationCode: "acme",
+            propertyCode: "prop",
+            environmentCode: nil,
+            jurisdictionCode: "us-ca",
+            languageCode: "en-US"
+        )
+        XCTAssertNil(request.configPathSegment())
+    }
+
+    func testConfigPathSegment_blankField_treatedAsAbsent() {
+        let request = KetchSDK.FullConfigurationRequest(
+            organizationCode: "acme",
+            propertyCode: "prop",
+            environmentCode: "",
+            jurisdictionCode: "us-ca",
+            languageCode: "en-US"
+        )
+        XCTAssertNil(request.configPathSegment(), "A blank environmentCode must be treated the same as nil")
+    }
+
+    func testConfigPathSegment_blankJurisdiction_treatedAsAbsent() {
+        let request = KetchSDK.FullConfigurationRequest(
+            organizationCode: "acme",
+            propertyCode: "prop",
+            environmentCode: "production",
+            jurisdictionCode: "",
+            languageCode: "en-US"
+        )
+        XCTAssertNil(request.configPathSegment())
+    }
+
+    func testConfigPathSegment_blankLanguage_treatedAsAbsent() {
+        let request = KetchSDK.FullConfigurationRequest(
+            organizationCode: "acme",
+            propertyCode: "prop",
+            environmentCode: "production",
+            jurisdictionCode: "us-ca",
+            languageCode: ""
+        )
+        XCTAssertNil(request.configPathSegment())
+    }
+
+    func testNormalizedHash_present_returnsHash() {
+        let request = KetchSDK.FullConfigurationRequest(
+            organizationCode: "acme",
+            propertyCode: "prop",
+            hash: "123"
+        )
+        XCTAssertEqual(request.normalizedHash(), "123")
+    }
+
+    func testNormalizedHash_nil_returnsNil() {
+        let request = KetchSDK.FullConfigurationRequest(organizationCode: "acme", propertyCode: "prop")
+        XCTAssertNil(request.normalizedHash())
+    }
+
+    func testNormalizedHash_blank_treatedAsAbsent() {
+        let request = KetchSDK.FullConfigurationRequest(
+            organizationCode: "acme",
+            propertyCode: "prop",
+            hash: ""
+        )
+        XCTAssertNil(request.normalizedHash())
+    }
+
+    func testFormatLanguageTag_underscoreSeparator_becomesHyphenWithUppercaseDialect() {
+        XCTAssertEqual(KetchSDK.FullConfigurationRequest.formatLanguageTag("fr_CA"), "fr-CA")
+    }
+
+    func testFormatLanguageTag_lowercaseDialect_isUppercased() {
+        XCTAssertEqual(KetchSDK.FullConfigurationRequest.formatLanguageTag("fr-ca"), "fr-CA")
+    }
+
+    func testFormatLanguageTag_rootOnly_isLowercased() {
+        XCTAssertEqual(KetchSDK.FullConfigurationRequest.formatLanguageTag("EN"), "en")
+    }
+
+    func testFormatLanguageTag_blank_fallsBackToEnglish() {
+        XCTAssertEqual(KetchSDK.FullConfigurationRequest.formatLanguageTag(""), "en")
+    }
+
+    func testConfigQueryItems_allPresent_onlyIncludesHash() {
+        let request = KetchSDK.FullConfigurationRequest(
+            organizationCode: "acme",
+            propertyCode: "prop",
+            environmentCode: "production",
+            jurisdictionCode: "us-ca",
+            languageCode: "en-US",
+            hash: "abc123"
+        )
+        XCTAssertEqual(request.configQueryItems(deviceLanguage: { "fr-CA" }), [URLQueryItem(name: "hash", value: "abc123")])
+    }
+
+    func testConfigQueryItems_allPresent_noHash_isEmpty() {
+        let request = KetchSDK.FullConfigurationRequest(
+            organizationCode: "acme",
+            propertyCode: "prop",
+            environmentCode: "production",
+            jurisdictionCode: "us-ca",
+            languageCode: "en-US"
+        )
+        XCTAssertEqual(request.configQueryItems(deviceLanguage: { "fr-CA" }), [])
+    }
+
+    func testConfigQueryItems_nothingSet_defaultsLanguageFromDevice() {
+        let request = KetchSDK.FullConfigurationRequest(organizationCode: "acme", propertyCode: "prop")
+        XCTAssertEqual(request.configQueryItems(deviceLanguage: { "fr-CA" }), [URLQueryItem(name: "language", value: "fr-CA")])
+    }
+
+    func testConfigQueryItems_explicitLanguage_winsOverDeviceLocale() {
+        let request = KetchSDK.FullConfigurationRequest(
+            organizationCode: "acme",
+            propertyCode: "prop",
+            languageCode: "de-DE"
+        )
+        XCTAssertEqual(request.configQueryItems(deviceLanguage: { "fr-CA" }), [URLQueryItem(name: "language", value: "de-DE")])
+    }
+
+    func testConfigQueryItems_jurisdictionOnly_includesJurisdictionAndDefaultedLanguage() {
+        let request = KetchSDK.FullConfigurationRequest(
+            organizationCode: "acme",
+            propertyCode: "prop",
+            jurisdictionCode: "us-ca"
+        )
+        XCTAssertEqual(
+            request.configQueryItems(deviceLanguage: { "fr-CA" }),
+            [URLQueryItem(name: "language", value: "fr-CA"), URLQueryItem(name: "jurisdiction", value: "us-ca")]
+        )
+    }
+
+    func testConfigQueryItems_regionOnly_includesRegionAndDefaultedLanguage() {
+        let request = KetchSDK.FullConfigurationRequest(
+            organizationCode: "acme",
+            propertyCode: "prop",
+            regionCode: "US-CA"
+        )
+        XCTAssertEqual(
+            request.configQueryItems(deviceLanguage: { "fr-CA" }),
+            [URLQueryItem(name: "language", value: "fr-CA"), URLQueryItem(name: "region", value: "US-CA")]
+        )
+    }
+
+    func testConfigQueryItems_blankFieldsTreatedAsAbsent() {
+        let request = KetchSDK.FullConfigurationRequest(
+            organizationCode: "acme",
+            propertyCode: "prop",
+            jurisdictionCode: "",
+            hash: "",
+            regionCode: ""
+        )
+        XCTAssertEqual(request.configQueryItems(deviceLanguage: { "fr-CA" }), [URLQueryItem(name: "language", value: "fr-CA")])
+    }
+}

--- a/Tests/KetchSDKTests/FullConfigurationRequestTests.swift
+++ b/Tests/KetchSDKTests/FullConfigurationRequestTests.swift
@@ -164,6 +164,15 @@ final class FullConfigurationRequestTests: XCTestCase {
         XCTAssertEqual(request.configQueryItems(deviceLanguage: { "fr-CA" }), [URLQueryItem(name: "language", value: "de-DE")])
     }
 
+    func testConfigQueryItems_explicitLanguage_normalized() {
+        let request = KetchSDK.FullConfigurationRequest(
+            organizationCode: "acme",
+            propertyCode: "prop",
+            languageCode: "fr_ca"
+        )
+        XCTAssertEqual(request.configQueryItems(deviceLanguage: { "en" }), [URLQueryItem(name: "language", value: "fr-CA")])
+    }
+
     func testConfigQueryItems_jurisdictionOnly_includesJurisdictionAndDefaultedLanguage() {
         let request = KetchSDK.FullConfigurationRequest(
             organizationCode: "acme",

--- a/Tests/KetchSDKTests/FullConfigurationRequestTests.swift
+++ b/Tests/KetchSDKTests/FullConfigurationRequestTests.swift
@@ -49,7 +49,7 @@ final class FullConfigurationRequestTests: XCTestCase {
         XCTAssertNil(request.configPathSegment())
     }
 
-    func testConfigPathSegment_blankLanguage_treatedAsAbsent() {
+    func testConfigPathSegment_blankLanguage_synthesizesDeviceLanguage() {
         let request = KetchSDK.FullConfigurationRequest(
             organizationCode: "acme",
             propertyCode: "prop",
@@ -57,7 +57,7 @@ final class FullConfigurationRequestTests: XCTestCase {
             jurisdictionCode: "us-ca",
             languageCode: ""
         )
-        XCTAssertNil(request.configPathSegment())
+        XCTAssertEqual(request.configPathSegment()?.language, KetchSDK.FullConfigurationRequest.deviceLanguageTag())
     }
 
     func testNormalizedHash_present_returnsHash() {
@@ -97,6 +97,34 @@ final class FullConfigurationRequestTests: XCTestCase {
 
     func testFormatLanguageTag_blank_fallsBackToEnglish() {
         XCTAssertEqual(KetchSDK.FullConfigurationRequest.formatLanguageTag(""), "en")
+    }
+
+    func testFormatLanguageTag_scriptAndRegion_bothPreserved() {
+        // A naive split-on-first-separator collapses this to "zh-HANS", dropping the region.
+        XCTAssertEqual(KetchSDK.FullConfigurationRequest.formatLanguageTag("zh-Hans-CN"), "zh-Hans-CN")
+    }
+
+    func testFormatLanguageTag_scriptOnly_titleCased() {
+        XCTAssertEqual(KetchSDK.FullConfigurationRequest.formatLanguageTag("zh-hans"), "zh-Hans")
+    }
+
+    func testFormatLanguageTag_numericRegion_uppercasedNoOp() {
+        XCTAssertEqual(KetchSDK.FullConfigurationRequest.formatLanguageTag("es-419"), "es-419")
+    }
+
+    func testConfigPathSegment_environmentAndJurisdictionSet_languageMissing_synthesizesDeviceLanguage() {
+        // Environment/jurisdiction must not be silently dropped to the short path just because
+        // the caller didn't also supply an explicit language.
+        let request = KetchSDK.FullConfigurationRequest(
+            organizationCode: "acme",
+            propertyCode: "prop",
+            environmentCode: "production",
+            jurisdictionCode: "us-ca"
+        )
+        let segment = request.configPathSegment()
+        XCTAssertEqual(segment?.env, "production")
+        XCTAssertEqual(segment?.jurisdiction, "us-ca")
+        XCTAssertEqual(segment?.language, KetchSDK.FullConfigurationRequest.deviceLanguageTag())
     }
 
     func testConfigQueryItems_allPresent_onlyIncludesHash() {

--- a/Tests/KetchSDKTests/HeadlessApiClientTests.swift
+++ b/Tests/KetchSDKTests/HeadlessApiClientTests.swift
@@ -1,0 +1,267 @@
+import Combine
+import XCTest
+@testable import KetchSDK
+
+final class HeadlessApiClientTests: XCTestCase {
+    private var client: HeadlessApiClient!
+    private var cancellables = Set<AnyCancellable>()
+
+    override func setUp() {
+        super.setUp()
+        client = HeadlessApiClient(dataCenter: .us)
+    }
+
+    func testBuildURL_ip() {
+        let url = client.buildURL(path: "/ip")
+        XCTAssertEqual(url?.absoluteString, "https://global.ketchcdn.com/web/v3/ip")
+    }
+
+    func testBuildURL_bootstrap() {
+        let url = client.buildURL(path: "/config/acme/prop/boot.json")
+        XCTAssertEqual(
+            url?.absoluteString,
+            "https://global.ketchcdn.com/web/v3/config/acme/prop/boot.json"
+        )
+    }
+
+    func testFetchConfig_includesPreferredLanguageQueryParam() throws {
+        let preferredLanguage = KetchSDK.FullConfigurationRequest.formatLanguageTag(Locale.preferredLanguages[0])
+        var capturedURL: URL?
+        let apiClient = CapturingApiClient { request in
+            capturedURL = request.endPoint.url
+            return Just(Data("{}".utf8))
+                .setFailureType(to: ApiClientError.self)
+                .eraseToAnyPublisher()
+        }
+        let client = HeadlessApiClient(dataCenter: .us, apiClient: apiClient)
+
+        let expectation = expectation(description: "fetchConfig language query")
+        client.fetchConfig(organization: "acme", property: "prop")
+            .sink(
+                receiveCompletion: { completion in
+                    if case .failure(let error) = completion {
+                        XCTFail("fetchConfig failed: \(error)")
+                    }
+                    expectation.fulfill()
+                },
+                receiveValue: { _ in }
+            )
+            .store(in: &cancellables)
+        wait(for: [expectation], timeout: 5)
+
+        let url = try XCTUnwrap(capturedURL)
+        XCTAssertEqual(url.path, "/web/v3/config/acme/prop/config.json")
+        XCTAssertEqual(
+            URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems,
+            [URLQueryItem(name: "language", value: preferredLanguage)]
+        )
+    }
+
+    func testGetFullConfiguration_blankEnvironment_omittedFromPath() throws {
+        var capturedURL: URL?
+        let apiClient = CapturingApiClient { request in
+            capturedURL = request.endPoint.url
+            return Just(Data("{}".utf8))
+                .setFailureType(to: ApiClientError.self)
+                .eraseToAnyPublisher()
+        }
+        let client = HeadlessApiClient(dataCenter: .us, apiClient: apiClient)
+
+        let expectation = expectation(description: "getFullConfiguration blank env")
+        client.getFullConfiguration(
+            request: .init(
+                organizationCode: "acme",
+                propertyCode: "prop",
+                environmentCode: "", // blank — must be treated as absent, not embedded as an empty path segment
+                jurisdictionCode: "us-ca",
+                languageCode: "en-US"
+            )
+        )
+        .sink(
+            receiveCompletion: { completion in
+                if case .failure(let error) = completion {
+                    XCTFail("getFullConfiguration failed: \(error)")
+                }
+                expectation.fulfill()
+            },
+            receiveValue: { _ in }
+        )
+        .store(in: &cancellables)
+        wait(for: [expectation], timeout: 5)
+
+        let url = try XCTUnwrap(capturedURL)
+        // A blank environmentCode must not produce a malformed path like ".../prop//us-ca/en-US/config.json".
+        XCTAssertEqual(url.path, "/web/v3/config/acme/prop/config.json")
+        XCTAssertEqual(
+            URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems,
+            [URLQueryItem(name: "language", value: "en-US"), URLQueryItem(name: "jurisdiction", value: "us-ca")]
+        )
+    }
+
+    func testGetFullConfiguration_nothingSet_shortPath_includesDeviceLanguage() throws {
+        var capturedURL: URL?
+        let apiClient = CapturingApiClient { request in
+            capturedURL = request.endPoint.url
+            return Just(Data("{}".utf8)).setFailureType(to: ApiClientError.self).eraseToAnyPublisher()
+        }
+        let client = HeadlessApiClient(dataCenter: .us, apiClient: apiClient)
+
+        let expectation = expectation(description: "getFullConfiguration nothing set")
+        client.getFullConfiguration(request: .init(organizationCode: "acme", propertyCode: "prop"))
+            .sink(
+                receiveCompletion: { completion in
+                    if case .failure(let error) = completion { XCTFail("getFullConfiguration failed: \(error)") }
+                    expectation.fulfill()
+                },
+                receiveValue: { _ in }
+            )
+            .store(in: &cancellables)
+        wait(for: [expectation], timeout: 5)
+
+        let url = try XCTUnwrap(capturedURL)
+        let deviceLanguage = KetchSDK.FullConfigurationRequest.formatLanguageTag(Locale.preferredLanguages[0])
+        XCTAssertEqual(url.path, "/web/v3/config/acme/prop/config.json")
+        XCTAssertEqual(
+            URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems,
+            [URLQueryItem(name: "language", value: deviceLanguage)]
+        )
+    }
+
+    func testGetFullConfiguration_explicitLanguage_winsOverDeviceLocale() throws {
+        var capturedURL: URL?
+        let apiClient = CapturingApiClient { request in
+            capturedURL = request.endPoint.url
+            return Just(Data("{}".utf8)).setFailureType(to: ApiClientError.self).eraseToAnyPublisher()
+        }
+        let client = HeadlessApiClient(dataCenter: .us, apiClient: apiClient)
+
+        let expectation = expectation(description: "getFullConfiguration explicit language")
+        client.getFullConfiguration(request: .init(organizationCode: "acme", propertyCode: "prop", languageCode: "de-DE"))
+            .sink(
+                receiveCompletion: { completion in
+                    if case .failure(let error) = completion { XCTFail("getFullConfiguration failed: \(error)") }
+                    expectation.fulfill()
+                },
+                receiveValue: { _ in }
+            )
+            .store(in: &cancellables)
+        wait(for: [expectation], timeout: 5)
+
+        let url = try XCTUnwrap(capturedURL)
+        XCTAssertEqual(
+            URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems,
+            [URLQueryItem(name: "language", value: "de-DE")]
+        )
+    }
+
+    func testGetFullConfiguration_blankHash_omittedFromQuery() throws {
+        var capturedURL: URL?
+        let apiClient = CapturingApiClient { request in
+            capturedURL = request.endPoint.url
+            return Just(Data("{}".utf8))
+                .setFailureType(to: ApiClientError.self)
+                .eraseToAnyPublisher()
+        }
+        let client = HeadlessApiClient(dataCenter: .us, apiClient: apiClient)
+
+        let expectation = expectation(description: "getFullConfiguration blank hash")
+        client.getFullConfiguration(
+            request: .init(
+                organizationCode: "acme",
+                propertyCode: "prop",
+                environmentCode: "production",
+                jurisdictionCode: "us-ca",
+                languageCode: "en-US",
+                hash: ""
+            )
+        )
+        .sink(
+            receiveCompletion: { completion in
+                if case .failure(let error) = completion {
+                    XCTFail("getFullConfiguration failed: \(error)")
+                }
+                expectation.fulfill()
+            },
+            receiveValue: { _ in }
+        )
+        .store(in: &cancellables)
+        wait(for: [expectation], timeout: 5)
+
+        let url = try XCTUnwrap(capturedURL)
+        XCTAssertNil(URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems, "A blank hash must not appear as a query param")
+    }
+
+    func testBuildURL_fullConfigurationWithHash() {
+        let url = client.buildURL(
+            path: "/config/acme/prop/prod/us-ca/en-US/config.json",
+            queryItems: [URLQueryItem(name: "hash", value: "8913461971881236311")]
+        )
+        XCTAssertEqual(
+            url?.absoluteString,
+            "https://global.ketchcdn.com/web/v3/config/acme/prop/prod/us-ca/en-US/config.json?hash=8913461971881236311"
+        )
+    }
+
+    func testBuildURL_euDataCenter() {
+        let eu = HeadlessApiClient(dataCenter: .eu)
+        let url = eu.buildURL(path: "/ip")
+        XCTAssertEqual(url?.absoluteString, "https://eu.ketchcdn.com/web/v3/ip")
+    }
+
+    func testGetPreferenceQRUrl_matchesContractFixture() {
+        let url = client.getPreferenceQRUrl(
+            request: .init(
+                organizationCode: "switchbitcorp",
+                propertyCode: "switchbit",
+                environmentCode: "production",
+                imageSize: 1024,
+                path: "/policy.html",
+                backgroundColor: "white",
+                foregroundColor: "black",
+                parameters: ["foo": "bar"]
+            )
+        )
+        XCTAssertEqual(
+            url?.absoluteString,
+            "https://global.ketchcdn.com/web/v3/qr/switchbitcorp/switchbit/preferences.png?env=production&size=1024&path=%2Fpolicy.html&bgcolor=white&fgcolor=black&foo=bar"
+        )
+    }
+
+    func testBuildURL_rightsProfileSubscriptions() {
+        let invoke = client.buildURL(path: "/rights/switchbitcorp/invoke")
+        XCTAssertEqual(
+            invoke?.absoluteString,
+            "https://global.ketchcdn.com/web/v3/rights/switchbitcorp/invoke"
+        )
+        let profile = client.buildURL(path: "/profile/acme/get")
+        XCTAssertEqual(
+            profile?.absoluteString,
+            "https://global.ketchcdn.com/web/v3/profile/acme/get"
+        )
+        let subs = client.buildURL(path: "/subscriptions/acme/update")
+        XCTAssertEqual(
+            subs?.absoluteString,
+            "https://global.ketchcdn.com/web/v3/subscriptions/acme/update"
+        )
+    }
+
+    func testKetchDataCenterBaseURLs() {
+        XCTAssertEqual(KetchDataCenter.us.baseURL.absoluteString, "https://global.ketchcdn.com/web/v3")
+        XCTAssertEqual(KetchDataCenter.eu.baseURL.absoluteString, "https://eu.ketchcdn.com/web/v3")
+        XCTAssertEqual(KetchDataCenter.uat.baseURL.absoluteString, "https://dev.ketchcdn.com/web/v3")
+    }
+}
+
+// MARK: - Test doubles
+
+private final class CapturingApiClient: ApiClient {
+    private let handler: (ApiRequest) -> AnyPublisher<Data, ApiClientError>
+
+    init(handler: @escaping (ApiRequest) -> AnyPublisher<Data, ApiClientError>) {
+        self.handler = handler
+    }
+
+    func execute(request: ApiRequest) -> AnyPublisher<Data, ApiClientError> {
+        handler(request)
+    }
+}

--- a/Tests/KetchSDKTests/HeadlessApiClientTests.swift
+++ b/Tests/KetchSDKTests/HeadlessApiClientTests.swift
@@ -187,6 +187,38 @@ final class HeadlessApiClientTests: XCTestCase {
         )
     }
 
+    func testGetFullConfiguration_explicitLanguage_normalizedOnLongPath() throws {
+        var capturedURL: URL?
+        let apiClient = CapturingApiClient { request in
+            capturedURL = request.endPoint.url
+            return Just(Data("{}".utf8)).setFailureType(to: ApiClientError.self).eraseToAnyPublisher()
+        }
+        let client = HeadlessApiClient(dataCenter: .us, apiClient: apiClient)
+
+        let expectation = expectation(description: "getFullConfiguration explicit unnormalized language")
+        client.getFullConfiguration(
+            request: .init(
+                organizationCode: "acme",
+                propertyCode: "prop",
+                environmentCode: "production",
+                jurisdictionCode: "us-ca",
+                languageCode: "fr_ca"
+            )
+        )
+        .sink(
+            receiveCompletion: { completion in
+                if case .failure(let error) = completion { XCTFail("getFullConfiguration failed: \(error)") }
+                expectation.fulfill()
+            },
+            receiveValue: { _ in }
+        )
+        .store(in: &cancellables)
+        wait(for: [expectation], timeout: 5)
+
+        let url = try XCTUnwrap(capturedURL)
+        XCTAssertEqual(url.path, "/web/v3/config/acme/prop/production/us-ca/fr-CA/config.json")
+    }
+
     func testGetFullConfiguration_blankHash_omittedFromQuery() throws {
         var capturedURL: URL?
         let apiClient = CapturingApiClient { request in

--- a/Tests/KetchSDKTests/HeadlessApiClientTests.swift
+++ b/Tests/KetchSDKTests/HeadlessApiClientTests.swift
@@ -98,6 +98,39 @@ final class HeadlessApiClientTests: XCTestCase {
         )
     }
 
+    func testGetFullConfiguration_environmentAndJurisdictionSet_languageMissing_takesLongPath() throws {
+        // Environment/jurisdiction must not be silently dropped to the short path just because
+        // the caller didn't also supply an explicit language.
+        var capturedURL: URL?
+        let apiClient = CapturingApiClient { request in
+            capturedURL = request.endPoint.url
+            return Just(Data("{}".utf8))
+                .setFailureType(to: ApiClientError.self)
+                .eraseToAnyPublisher()
+        }
+        let client = HeadlessApiClient(dataCenter: .us, apiClient: apiClient)
+
+        let expectation = expectation(description: "getFullConfiguration language missing")
+        client.getFullConfiguration(
+            request: .init(organizationCode: "acme", propertyCode: "prop", environmentCode: "production", jurisdictionCode: "us-ca")
+        )
+        .sink(
+            receiveCompletion: { completion in
+                if case .failure(let error) = completion {
+                    XCTFail("getFullConfiguration failed: \(error)")
+                }
+                expectation.fulfill()
+            },
+            receiveValue: { _ in }
+        )
+        .store(in: &cancellables)
+        wait(for: [expectation], timeout: 5)
+
+        let url = try XCTUnwrap(capturedURL)
+        let deviceLanguage = KetchSDK.FullConfigurationRequest.deviceLanguageTag()
+        XCTAssertEqual(url.path, "/web/v3/config/acme/prop/production/us-ca/\(deviceLanguage)/config.json")
+    }
+
     func testGetFullConfiguration_nothingSet_shortPath_includesDeviceLanguage() throws {
         var capturedURL: URL?
         let apiClient = CapturingApiClient { request in

--- a/Tests/KetchSDKTests/HeadlessCdnIntegrationTests.swift
+++ b/Tests/KetchSDKTests/HeadlessCdnIntegrationTests.swift
@@ -1,0 +1,112 @@
+import Combine
+import XCTest
+@testable import KetchSDK
+
+/// Live CDN headless round-trip tests (web/v3, sandbox org).
+///
+/// Run with network enabled:
+/// `KETCH_INTEGRATION_TESTS=1 xcodebuild -scheme KetchSDK -destination 'platform=iOS Simulator,name=iPhone 17' test -only-testing:KetchSDKTests/HeadlessCdnIntegrationTests`
+final class HeadlessCdnIntegrationTests: XCTestCase {
+    private var client: HeadlessApiClient!
+    private var cancellables: Set<AnyCancellable> = []
+
+    override func setUp() {
+        super.setUp()
+        try? XCTSkipUnless(
+            ProcessInfo.processInfo.environment["KETCH_INTEGRATION_TESTS"] == "1",
+            "Set KETCH_INTEGRATION_TESTS=1 to run live CDN tests"
+        )
+        client = HeadlessApiClient(dataCenter: .us)
+        cancellables = []
+    }
+
+    override func tearDown() {
+        cancellables.removeAll()
+        super.tearDown()
+    }
+
+    func testFetchLocationReturnsGeoIP() {
+        let expectation = expectation(description: "getLocation")
+        client.getLocation()
+            .sink(
+                receiveCompletion: { completion in
+                    if case .failure(let error) = completion {
+                        XCTFail("getLocation failed: \(error)")
+                    }
+                    expectation.fulfill()
+                },
+                receiveValue: { response in
+                    XCTAssertFalse(response.location?.countryCode?.isEmpty ?? true)
+                }
+            )
+            .store(in: &cancellables)
+        wait(for: [expectation], timeout: 45)
+    }
+
+    func testFetchBootstrapConfiguration() {
+        let expectation = expectation(description: "getBootstrapConfiguration")
+        client.getBootstrapConfiguration(
+            organization: HeadlessIntegrationSupport.orgCode,
+            property: HeadlessIntegrationSupport.propertyCode
+        )
+        .sink(
+            receiveCompletion: { completion in
+                if case .failure(let error) = completion {
+                    XCTFail("getBootstrapConfiguration failed: \(error)")
+                }
+                expectation.fulfill()
+            },
+            receiveValue: { boot in
+                let hasMetadata = boot.experiences != nil
+                    || boot.jurisdiction != nil
+                    || !(boot.purposes?.isEmpty ?? true)
+                XCTAssertTrue(hasMetadata, "Bootstrap should include experiences metadata")
+            }
+        )
+        .store(in: &cancellables)
+        wait(for: [expectation], timeout: 45)
+    }
+
+    func testHeadlessColdStartConsentRoundTrip() {
+        let identities = HeadlessIntegrationSupport.uniqueEmailIdentity()
+        let expectation = expectation(description: "coldStart")
+
+        client.getBootstrapConfiguration(
+            organization: HeadlessIntegrationSupport.orgCode,
+            property: HeadlessIntegrationSupport.propertyCode
+        )
+        .flatMap { _ in
+            self.client.getFullConfiguration(
+                request: .init(
+                    organizationCode: HeadlessIntegrationSupport.orgCode,
+                    propertyCode: HeadlessIntegrationSupport.propertyCode
+                )
+            )
+        }
+        .map { full in
+            HeadlessIntegrationSupport.consentConfigFrom(
+                configuration: full,
+                identities: identities
+            )
+        }
+        .flatMap { config in
+            self.client.getConsent(config: config)
+        }
+        .sink(
+            receiveCompletion: { completion in
+                if case .failure(let error) = completion {
+                    XCTFail("cold start failed: \(error)")
+                }
+                expectation.fulfill()
+            },
+            receiveValue: { consent in
+                let hasProtocols = !(consent.protocols?.isEmpty ?? true)
+                let hasPurposes = !(consent.purposes?.isEmpty ?? true)
+                XCTAssertTrue(hasProtocols || hasPurposes, "Expected protocols and/or purposes from CDN")
+            }
+        )
+        .store(in: &cancellables)
+
+        wait(for: [expectation], timeout: 60)
+    }
+}

--- a/Tests/KetchSDKTests/HeadlessCdnIntegrationTests.swift
+++ b/Tests/KetchSDKTests/HeadlessCdnIntegrationTests.swift
@@ -10,9 +10,9 @@ final class HeadlessCdnIntegrationTests: XCTestCase {
     private var client: HeadlessApiClient!
     private var cancellables: Set<AnyCancellable> = []
 
-    override func setUp() {
-        super.setUp()
-        try? XCTSkipUnless(
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        try XCTSkipUnless(
             ProcessInfo.processInfo.environment["KETCH_INTEGRATION_TESTS"] == "1",
             "Set KETCH_INTEGRATION_TESTS=1 to run live CDN tests"
         )

--- a/Tests/KetchSDKTests/HeadlessConsentTests.swift
+++ b/Tests/KetchSDKTests/HeadlessConsentTests.swift
@@ -1,0 +1,319 @@
+import Combine
+import XCTest
+@testable import KetchSDK
+
+final class HeadlessConsentTests: XCTestCase {
+    private var cancellables: Set<AnyCancellable> = []
+
+    override func tearDown() {
+        cancellables.removeAll()
+        StubURLProtocol.handler = nil
+        super.tearDown()
+    }
+    func testSetConsentPayloadOmitsProtocols() throws {
+        let update = KetchSDK.ConsentUpdate(
+            organizationCode: "org",
+            propertyCode: "prop",
+            environmentCode: "production",
+            identities: ["id": "1"],
+            jurisdictionCode: "default",
+            migrationOption: .migrateDefault,
+            purposes: [
+                "analytics": .init(allowed: true, legalBasisCode: "consent_optin"),
+            ],
+            vendors: nil,
+            protocols: ["gpp": "DBABLA~"]
+        )
+        let payload = SetConsentPayloadForTesting(update: update)
+        let data = try JSONEncoder().encode(payload)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertNil(json["protocols"])
+        XCTAssertEqual(json["organizationCode"] as? String, "org")
+    }
+
+    func testFetchConsentPropagatesHTTPFailure() {
+        let session = makeStubSession()
+        let client = HeadlessApiClient(dataCenter: .us, session: session)
+        StubURLProtocol.handler = { _ in
+            let response = HTTPURLResponse(
+                url: URL(string: "https://global.ketchcdn.com/web/v3/consent/org/get")!,
+                statusCode: 500,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data())
+        }
+
+        let expectation = expectation(description: "getConsent failure")
+        client.getConsent(config: sampleConsentConfig())
+            .sink(
+                receiveCompletion: { completion in
+                    if case .failure = completion {
+                        expectation.fulfill()
+                    } else {
+                        XCTFail("Expected getConsent to fail on HTTP 500")
+                    }
+                },
+                receiveValue: { _ in
+                    XCTFail("Expected no value on HTTP 500")
+                }
+            )
+            .store(in: &cancellables)
+        wait(for: [expectation], timeout: 5)
+    }
+
+    func testSetConsentPropagatesNetworkFailure() {
+        let session = makeStubSession()
+        let client = HeadlessApiClient(dataCenter: .us, session: session)
+        StubURLProtocol.handler = { _ in
+            throw URLError(.notConnectedToInternet)
+        }
+
+        let expectation = expectation(description: "setConsent failure")
+        client.setConsent(update: sampleConsentUpdate())
+            .sink(
+                receiveCompletion: { completion in
+                    if case .failure = completion {
+                        expectation.fulfill()
+                    } else {
+                        XCTFail("Expected setConsent to fail on network error")
+                    }
+                },
+                receiveValue: { _ in
+                    XCTFail("Expected no value on network error")
+                }
+            )
+            .store(in: &cancellables)
+        wait(for: [expectation], timeout: 5)
+    }
+
+    func testSetConsentAcceptsProtocolsOnlyResponse() throws {
+        let session = makeStubSession()
+        let client = HeadlessApiClient(dataCenter: .us, session: session)
+        let body = """
+        {"protocols":{"gpp":"DBABLA~BVQqAAAAAAJY.QA"}}
+        """
+        StubURLProtocol.handler = { _ in
+            let response = HTTPURLResponse(
+                url: URL(string: "https://global.ketchcdn.com/web/v3/consent/org/update")!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data(body.utf8))
+        }
+
+        let expectation = expectation(description: "setConsent protocols")
+        client.setConsent(update: sampleConsentUpdate())
+            .sink(
+                receiveCompletion: { completion in
+                    if case .failure(let error) = completion {
+                        XCTFail("setConsent failed: \(error)")
+                    }
+                    expectation.fulfill()
+                },
+                receiveValue: { status in
+                    XCTAssertNil(status.purposes)
+                    XCTAssertEqual(status.protocols?["gpp"], "DBABLA~BVQqAAAAAAJY.QA")
+                }
+            )
+            .store(in: &cancellables)
+        wait(for: [expectation], timeout: 5)
+    }
+
+    func testSetConsentFallsBackToCallerProtocolsWhenResponseOmitsThem() throws {
+        let session = makeStubSession()
+        let client = HeadlessApiClient(dataCenter: .us, session: session)
+        let body = """
+        {"purposes":{"analytics":true}}
+        """
+        StubURLProtocol.handler = { _ in
+            let response = HTTPURLResponse(
+                url: URL(string: "https://global.ketchcdn.com/web/v3/consent/org/update")!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data(body.utf8))
+        }
+
+        var update = sampleConsentUpdate()
+        update = .init(
+            organizationCode: update.organizationCode,
+            propertyCode: update.propertyCode,
+            environmentCode: update.environmentCode,
+            identities: update.identities,
+            jurisdictionCode: update.jurisdictionCode,
+            migrationOption: update.migrationOption,
+            purposes: update.purposes,
+            vendors: update.vendors,
+            protocols: ["gpp": "DBABLA~BVQqAAAAAAJY.QA"]
+        )
+
+        let expectation = expectation(description: "setConsent caller protocols")
+        client.setConsent(update: update)
+            .sink(
+                receiveCompletion: { completion in
+                    if case .failure(let error) = completion {
+                        XCTFail("setConsent failed: \(error)")
+                    }
+                    expectation.fulfill()
+                },
+                receiveValue: { status in
+                    XCTAssertEqual(status.purposes?["analytics"], true)
+                    XCTAssertEqual(status.protocols?["gpp"], "DBABLA~BVQqAAAAAAJY.QA")
+                }
+            )
+            .store(in: &cancellables)
+        wait(for: [expectation], timeout: 5)
+    }
+
+    func testFetchConsentAcceptsVendorsOnlyResponse() throws {
+        let session = makeStubSession()
+        let client = HeadlessApiClient(dataCenter: .us, session: session)
+        let body = """
+        {"vendors":["google","meta"]}
+        """
+        StubURLProtocol.handler = { _ in
+            let response = HTTPURLResponse(
+                url: URL(string: "https://global.ketchcdn.com/web/v3/consent/org/get")!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data(body.utf8))
+        }
+
+        let expectation = expectation(description: "getConsent vendors")
+        client.getConsent(config: sampleConsentConfig())
+            .sink(
+                receiveCompletion: { completion in
+                    if case .failure(let error) = completion {
+                        XCTFail("getConsent failed: \(error)")
+                    }
+                    expectation.fulfill()
+                },
+                receiveValue: { status in
+                    XCTAssertNil(status.purposes)
+                    XCTAssertEqual(status.vendors, ["google", "meta"])
+                    XCTAssertNil(status.protocols)
+                }
+            )
+            .store(in: &cancellables)
+        wait(for: [expectation], timeout: 5)
+    }
+
+    func testConsentConfigPayloadOmitsCachedAt() throws {
+        let config = KetchSDK.ConsentConfig(
+            organizationCode: "org",
+            propertyCode: "prop",
+            environmentCode: "production",
+            jurisdictionCode: "default",
+            identities: [:],
+            purposes: [:]
+        )
+        let payload = ConsentConfigPayloadForTesting(config: config)
+        let data = try JSONEncoder().encode(payload)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertNil(json["cachedAt"])
+    }
+}
+
+// MARK: - Consent HTTP stubs
+
+private func makeStubSession() -> URLSession {
+    let config = URLSessionConfiguration.ephemeral
+    config.protocolClasses = [StubURLProtocol.self]
+    return URLSession(configuration: config)
+}
+
+private func sampleConsentConfig() -> KetchSDK.ConsentConfig {
+    .init(
+        organizationCode: "org",
+        propertyCode: "prop",
+        environmentCode: "production",
+        jurisdictionCode: "default",
+        identities: ["email": "user@example.com"],
+        purposes: ["analytics": .init(legalBasisCode: "consent_optin")]
+    )
+}
+
+private func sampleConsentUpdate() -> KetchSDK.ConsentUpdate {
+    .init(
+        organizationCode: "org",
+        propertyCode: "prop",
+        environmentCode: "production",
+        identities: ["email": "user@example.com"],
+        jurisdictionCode: "default",
+        migrationOption: .migrateDefault,
+        purposes: ["analytics": .init(allowed: true, legalBasisCode: "consent_optin")],
+        vendors: nil,
+        protocols: nil
+    )
+}
+
+private final class StubURLProtocol: URLProtocol {
+    static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = Self.handler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.unknown))
+            return
+        }
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+/// Mirrors private `SetConsentPayload` in HeadlessApiClient for contract tests.
+private struct SetConsentPayloadForTesting: Encodable {
+    let organizationCode: String
+    let propertyCode: String
+    let environmentCode: String
+    let identities: [String: String]
+    let jurisdictionCode: String
+    let migrationOption: KetchSDK.ConsentUpdate.MigrationOption
+    let purposes: [String: KetchSDK.ConsentUpdate.PurposeAllowedLegalBasis]
+    let vendors: [String]?
+
+    init(update: KetchSDK.ConsentUpdate) {
+        organizationCode = update.organizationCode
+        propertyCode = update.propertyCode
+        environmentCode = update.environmentCode
+        identities = update.identities
+        jurisdictionCode = update.jurisdictionCode
+        migrationOption = update.migrationOption
+        purposes = update.purposes
+        vendors = update.vendors
+    }
+}
+
+private struct ConsentConfigPayloadForTesting: Encodable {
+    let organizationCode: String
+    let propertyCode: String
+    let environmentCode: String
+    let jurisdictionCode: String
+    let identities: [String: String]
+    let purposes: [String: KetchSDK.ConsentConfig.PurposeLegalBasis]
+
+    init(config: KetchSDK.ConsentConfig) {
+        organizationCode = config.organizationCode
+        propertyCode = config.propertyCode
+        environmentCode = config.environmentCode
+        jurisdictionCode = config.jurisdictionCode
+        identities = config.identities
+        purposes = config.purposes
+    }
+}

--- a/Tests/KetchSDKTests/HeadlessConsentTests.swift
+++ b/Tests/KetchSDKTests/HeadlessConsentTests.swift
@@ -7,7 +7,6 @@ final class HeadlessConsentTests: XCTestCase {
 
     override func tearDown() {
         cancellables.removeAll()
-        StubURLProtocol.handler = nil
         super.tearDown()
     }
     func testSetConsentPayloadOmitsProtocols() throws {
@@ -32,17 +31,9 @@ final class HeadlessConsentTests: XCTestCase {
     }
 
     func testFetchConsentPropagatesHTTPFailure() {
-        let session = makeStubSession()
-        let client = HeadlessApiClient(dataCenter: .us, session: session)
-        StubURLProtocol.handler = { _ in
-            let response = HTTPURLResponse(
-                url: URL(string: "https://global.ketchcdn.com/web/v3/consent/org/get")!,
-                statusCode: 500,
-                httpVersion: nil,
-                headerFields: nil
-            )!
-            return (response, Data())
-        }
+        let client = HeadlessApiClient(dataCenter: .us, apiClient: StubApiClient { _ in
+            Fail(error: .unknownError).eraseToAnyPublisher()
+        })
 
         let expectation = expectation(description: "getConsent failure")
         client.getConsent(config: sampleConsentConfig())
@@ -63,11 +54,9 @@ final class HeadlessConsentTests: XCTestCase {
     }
 
     func testSetConsentPropagatesNetworkFailure() {
-        let session = makeStubSession()
-        let client = HeadlessApiClient(dataCenter: .us, session: session)
-        StubURLProtocol.handler = { _ in
-            throw URLError(.notConnectedToInternet)
-        }
+        let client = HeadlessApiClient(dataCenter: .us, apiClient: StubApiClient { _ in
+            Fail(error: .unknownError).eraseToAnyPublisher()
+        })
 
         let expectation = expectation(description: "setConsent failure")
         client.setConsent(update: sampleConsentUpdate())
@@ -88,20 +77,12 @@ final class HeadlessConsentTests: XCTestCase {
     }
 
     func testSetConsentAcceptsProtocolsOnlyResponse() throws {
-        let session = makeStubSession()
-        let client = HeadlessApiClient(dataCenter: .us, session: session)
         let body = """
         {"protocols":{"gpp":"DBABLA~BVQqAAAAAAJY.QA"}}
         """
-        StubURLProtocol.handler = { _ in
-            let response = HTTPURLResponse(
-                url: URL(string: "https://global.ketchcdn.com/web/v3/consent/org/update")!,
-                statusCode: 200,
-                httpVersion: nil,
-                headerFields: nil
-            )!
-            return (response, Data(body.utf8))
-        }
+        let client = HeadlessApiClient(dataCenter: .us, apiClient: StubApiClient { _ in
+            Just(Data(body.utf8)).setFailureType(to: ApiClientError.self).eraseToAnyPublisher()
+        })
 
         let expectation = expectation(description: "setConsent protocols")
         client.setConsent(update: sampleConsentUpdate())
@@ -122,20 +103,12 @@ final class HeadlessConsentTests: XCTestCase {
     }
 
     func testSetConsentFallsBackToCallerProtocolsWhenResponseOmitsThem() throws {
-        let session = makeStubSession()
-        let client = HeadlessApiClient(dataCenter: .us, session: session)
         let body = """
         {"purposes":{"analytics":true}}
         """
-        StubURLProtocol.handler = { _ in
-            let response = HTTPURLResponse(
-                url: URL(string: "https://global.ketchcdn.com/web/v3/consent/org/update")!,
-                statusCode: 200,
-                httpVersion: nil,
-                headerFields: nil
-            )!
-            return (response, Data(body.utf8))
-        }
+        let client = HeadlessApiClient(dataCenter: .us, apiClient: StubApiClient { _ in
+            Just(Data(body.utf8)).setFailureType(to: ApiClientError.self).eraseToAnyPublisher()
+        })
 
         var update = sampleConsentUpdate()
         update = .init(
@@ -169,20 +142,12 @@ final class HeadlessConsentTests: XCTestCase {
     }
 
     func testFetchConsentAcceptsVendorsOnlyResponse() throws {
-        let session = makeStubSession()
-        let client = HeadlessApiClient(dataCenter: .us, session: session)
         let body = """
         {"vendors":["google","meta"]}
         """
-        StubURLProtocol.handler = { _ in
-            let response = HTTPURLResponse(
-                url: URL(string: "https://global.ketchcdn.com/web/v3/consent/org/get")!,
-                statusCode: 200,
-                httpVersion: nil,
-                headerFields: nil
-            )!
-            return (response, Data(body.utf8))
-        }
+        let client = HeadlessApiClient(dataCenter: .us, apiClient: StubApiClient { _ in
+            Just(Data(body.utf8)).setFailureType(to: ApiClientError.self).eraseToAnyPublisher()
+        })
 
         let expectation = expectation(description: "getConsent vendors")
         client.getConsent(config: sampleConsentConfig())
@@ -221,10 +186,16 @@ final class HeadlessConsentTests: XCTestCase {
 
 // MARK: - Consent HTTP stubs
 
-private func makeStubSession() -> URLSession {
-    let config = URLSessionConfiguration.ephemeral
-    config.protocolClasses = [StubURLProtocol.self]
-    return URLSession(configuration: config)
+private final class StubApiClient: ApiClient {
+    private let handler: (ApiRequest) -> AnyPublisher<Data, ApiClientError>
+
+    init(handler: @escaping (ApiRequest) -> AnyPublisher<Data, ApiClientError>) {
+        self.handler = handler
+    }
+
+    func execute(request: ApiRequest) -> AnyPublisher<Data, ApiClientError> {
+        handler(request)
+    }
 }
 
 private func sampleConsentConfig() -> KetchSDK.ConsentConfig {
@@ -250,31 +221,6 @@ private func sampleConsentUpdate() -> KetchSDK.ConsentUpdate {
         vendors: nil,
         protocols: nil
     )
-}
-
-private final class StubURLProtocol: URLProtocol {
-    static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
-
-    override class func canInit(with request: URLRequest) -> Bool { true }
-
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
-
-    override func startLoading() {
-        guard let handler = Self.handler else {
-            client?.urlProtocol(self, didFailWithError: URLError(.unknown))
-            return
-        }
-        do {
-            let (response, data) = try handler(request)
-            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-            client?.urlProtocol(self, didLoad: data)
-            client?.urlProtocolDidFinishLoading(self)
-        } catch {
-            client?.urlProtocol(self, didFailWithError: error)
-        }
-    }
-
-    override func stopLoading() {}
 }
 
 /// Mirrors private `SetConsentPayload` in HeadlessApiClient for contract tests.

--- a/Tests/KetchSDKTests/HeadlessIntegrationSupport.swift
+++ b/Tests/KetchSDKTests/HeadlessIntegrationSupport.swift
@@ -1,0 +1,45 @@
+import Foundation
+@testable import KetchSDK
+
+/// Shared sandbox config for live CDN integration tests.
+enum HeadlessIntegrationSupport {
+    static let orgCode = "ketch_samples"
+    static let propertyCode = "ios"
+    static let environmentCode = "production"
+
+    static func uniqueEmailIdentity() -> [String: String] {
+        ["email": "headless-\(UUID().uuidString)@integration.ketch.test"]
+    }
+
+    static func consentConfigFrom(
+        configuration: KetchSDK.Configuration,
+        identities: [String: String],
+        organizationCode: String = orgCode,
+        propertyCode: String = propertyCode,
+        environmentCode: String = environmentCode
+    ) -> KetchSDK.ConsentConfig {
+        let jurisdiction = configuration.jurisdiction?.code
+            ?? configuration.jurisdiction?.defaultJurisdictionCode
+            ?? "us"
+        let purposesList = configuration.purposes ?? []
+        let purposeMap = Dictionary(
+            uniqueKeysWithValues: purposesList.map { purpose in
+                (
+                    purpose.code,
+                    KetchSDK.ConsentConfig.PurposeLegalBasis(
+                        legalBasisCode: purpose.legalBasisCode
+                    )
+                )
+            }
+        )
+        precondition(!purposeMap.isEmpty, "Configuration returned no purposes")
+        return KetchSDK.ConsentConfig(
+            organizationCode: organizationCode,
+            propertyCode: propertyCode,
+            environmentCode: environmentCode,
+            jurisdictionCode: jurisdiction,
+            identities: identities,
+            purposes: purposeMap
+        )
+    }
+}

--- a/Tests/KetchSDKTests/KetchHeadlessCachingTests.swift
+++ b/Tests/KetchSDKTests/KetchHeadlessCachingTests.swift
@@ -1,0 +1,198 @@
+import Combine
+import XCTest
+@testable import KetchSDK
+
+final class KetchHeadlessCachingTests: XCTestCase {
+    func testGetRegion_cachesLocationAcrossCalls() {
+        let apiClient = CountingApiClient { _ in
+            Just(Data("""
+            {"location":{"countryCode":"US","regionCode":"CA"}}
+            """.utf8))
+                .setFailureType(to: ApiClientError.self)
+                .eraseToAnyPublisher()
+        }
+        let ketch = Ketch(
+            organizationCode: "acme",
+            propertyCode: "prop",
+            environmentCode: "production",
+            identities: [],
+            apiClient: apiClient
+        )
+
+        let first = expectation(description: "first getRegion")
+        ketch.getRegion { result in
+            XCTAssertEqual(try? result.get(), "US-CA")
+            first.fulfill()
+        }
+        wait(for: [first], timeout: 5)
+
+        let second = expectation(description: "second getRegion")
+        ketch.getRegion { result in
+            XCTAssertEqual(try? result.get(), "US-CA")
+            second.fulfill()
+        }
+        wait(for: [second], timeout: 5)
+
+        XCTAssertEqual(apiClient.callCount, 1, "getRegion should hit the network only once; repeat calls should be served from cache")
+    }
+
+    func testGetFullConfiguration_sameRequest_servedFromCache() {
+        let apiClient = CountingApiClient { _ in
+            Just(Data("{}".utf8)).setFailureType(to: ApiClientError.self).eraseToAnyPublisher()
+        }
+        let ketch = Ketch(
+            organizationCode: "acme",
+            propertyCode: "prop",
+            environmentCode: "production",
+            identities: [],
+            apiClient: apiClient
+        )
+        let request = KetchSDK.FullConfigurationRequest(
+            organizationCode: "acme",
+            propertyCode: "prop",
+            environmentCode: "production",
+            jurisdictionCode: "us-ca",
+            languageCode: "en-US"
+        )
+
+        let first = expectation(description: "first getFullConfiguration")
+        ketch.getFullConfiguration(request: request) { _ in first.fulfill() }
+        wait(for: [first], timeout: 5)
+
+        let second = expectation(description: "second getFullConfiguration")
+        ketch.getFullConfiguration(request: request) { _ in second.fulfill() }
+        wait(for: [second], timeout: 5)
+
+        XCTAssertEqual(apiClient.callCount, 1, "Identical requests should be served from the config cache")
+    }
+
+    func testGetFullConfiguration_differentRequest_missesCache() {
+        let apiClient = CountingApiClient { _ in
+            Just(Data("{}".utf8)).setFailureType(to: ApiClientError.self).eraseToAnyPublisher()
+        }
+        let ketch = Ketch(
+            organizationCode: "acme",
+            propertyCode: "prop",
+            environmentCode: "production",
+            identities: [],
+            apiClient: apiClient
+        )
+
+        let first = expectation(description: "first getFullConfiguration")
+        ketch.getFullConfiguration(
+            request: .init(
+                organizationCode: "acme",
+                propertyCode: "prop",
+                environmentCode: "production",
+                jurisdictionCode: "us-ca",
+                languageCode: "en-US"
+            )
+        ) { _ in first.fulfill() }
+        wait(for: [first], timeout: 5)
+
+        let second = expectation(description: "second getFullConfiguration, different jurisdiction")
+        ketch.getFullConfiguration(
+            request: .init(
+                organizationCode: "acme",
+                propertyCode: "prop",
+                environmentCode: "production",
+                jurisdictionCode: "eu-fr",
+                languageCode: "en-US"
+            )
+        ) { _ in second.fulfill() }
+        wait(for: [second], timeout: 5)
+
+        XCTAssertEqual(apiClient.callCount, 2, "Requests that hit different config URLs must not share a cache entry")
+    }
+
+    func testGetFullConfiguration_differentRegionOnShortPath_missesCache() {
+        let apiClient = CountingApiClient { _ in
+            Just(Data("{}".utf8)).setFailureType(to: ApiClientError.self).eraseToAnyPublisher()
+        }
+        let ketch = Ketch(
+            organizationCode: "acme",
+            propertyCode: "prop",
+            environmentCode: "production",
+            identities: [],
+            apiClient: apiClient
+        )
+
+        let first = expectation(description: "first getFullConfiguration")
+        ketch.getFullConfiguration(
+            request: .init(organizationCode: "acme", propertyCode: "prop", regionCode: "US-CA")
+        ) { _ in first.fulfill() }
+        wait(for: [first], timeout: 5)
+
+        let second = expectation(description: "second getFullConfiguration, different region")
+        ketch.getFullConfiguration(
+            request: .init(organizationCode: "acme", propertyCode: "prop", regionCode: "US-NY")
+        ) { _ in second.fulfill() }
+        wait(for: [second], timeout: 5)
+
+        XCTAssertEqual(apiClient.callCount, 2, "A regionCode-only difference on the short path must not share a cache entry")
+    }
+
+    func testGetJurisdiction_returnsCodeFromConfig() {
+        let apiClient = CountingApiClient { _ in
+            Just(Data("""
+            {"jurisdiction":{"code":"us-ca","defaultJurisdictionCode":"us"}}
+            """.utf8))
+                .setFailureType(to: ApiClientError.self)
+                .eraseToAnyPublisher()
+        }
+        let ketch = Ketch(
+            organizationCode: "acme",
+            propertyCode: "prop",
+            environmentCode: "production",
+            identities: [],
+            apiClient: apiClient
+        )
+
+        let expectation = expectation(description: "getJurisdiction")
+        ketch.getJurisdiction { result in
+            XCTAssertEqual(try? result.get(), "us-ca")
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 5)
+    }
+
+    func testGetJurisdiction_fallsBackToDefaultJurisdictionCode() {
+        let apiClient = CountingApiClient { _ in
+            Just(Data("""
+            {"jurisdiction":{"defaultJurisdictionCode":"us"}}
+            """.utf8))
+                .setFailureType(to: ApiClientError.self)
+                .eraseToAnyPublisher()
+        }
+        let ketch = Ketch(
+            organizationCode: "acme",
+            propertyCode: "prop",
+            environmentCode: "production",
+            identities: [],
+            apiClient: apiClient
+        )
+
+        let expectation = expectation(description: "getJurisdiction fallback")
+        ketch.getJurisdiction { result in
+            XCTAssertEqual(try? result.get(), "us")
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 5)
+    }
+}
+
+// MARK: - Test doubles
+
+private final class CountingApiClient: ApiClient {
+    private(set) var callCount = 0
+    private let handler: (ApiRequest) -> AnyPublisher<Data, ApiClientError>
+
+    init(handler: @escaping (ApiRequest) -> AnyPublisher<Data, ApiClientError>) {
+        self.handler = handler
+    }
+
+    func execute(request: ApiRequest) -> AnyPublisher<Data, ApiClientError> {
+        callCount += 1
+        return handler(request)
+    }
+}

--- a/Tests/KetchSDKTests/KetchHeadlessLiveIntegrationTests.swift
+++ b/Tests/KetchSDKTests/KetchHeadlessLiveIntegrationTests.swift
@@ -9,9 +9,9 @@ import XCTest
 final class KetchHeadlessLiveIntegrationTests: XCTestCase {
     private var cancellables: Set<AnyCancellable> = []
 
-    override func setUp() {
-        super.setUp()
-        try? XCTSkipUnless(
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        try XCTSkipUnless(
             ProcessInfo.processInfo.environment["KETCH_INTEGRATION_TESTS"] == "1",
             "Set KETCH_INTEGRATION_TESTS=1 to run live CDN tests"
         )
@@ -86,11 +86,11 @@ final class KetchHeadlessLiveIntegrationTests: XCTestCase {
         KetchSDK.getRegion()
             .sink { completion in
                 if case .failure(let error) = completion { XCTFail("static getRegion failed: \(error)") }
+                expectation.fulfill()
             } receiveValue: { region in
                 XCTAssertFalse(region?.isEmpty ?? true, "Expected a non-empty region code from live GeoIP")
             }
             .store(in: &cancellables)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 5) { expectation.fulfill() }
         wait(for: [expectation], timeout: 45)
     }
 
@@ -104,11 +104,11 @@ final class KetchHeadlessLiveIntegrationTests: XCTestCase {
         KetchSDK.getJurisdiction(request: request)
             .sink { completion in
                 if case .failure(let error) = completion { XCTFail("static getJurisdiction failed: \(error)") }
+                expectation.fulfill()
             } receiveValue: { jurisdiction in
                 XCTAssertFalse(jurisdiction?.isEmpty ?? true, "Expected a non-empty jurisdiction code from live config")
             }
             .store(in: &cancellables)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 5) { expectation.fulfill() }
         wait(for: [expectation], timeout: 45)
     }
 

--- a/Tests/KetchSDKTests/KetchHeadlessLiveIntegrationTests.swift
+++ b/Tests/KetchSDKTests/KetchHeadlessLiveIntegrationTests.swift
@@ -1,0 +1,147 @@
+import Combine
+import XCTest
+@testable import KetchSDK
+
+/// Live CDN round-trip for the ported getRegion/getJurisdiction/trigger surface (sandbox org).
+///
+/// Run with network enabled:
+/// `KETCH_INTEGRATION_TESTS=1 xcodebuild -scheme KetchSDK -destination 'platform=iOS Simulator,name=iPhone 17' test -only-testing:KetchSDKTests/KetchHeadlessLiveIntegrationTests`
+final class KetchHeadlessLiveIntegrationTests: XCTestCase {
+    private var cancellables: Set<AnyCancellable> = []
+
+    override func setUp() {
+        super.setUp()
+        try? XCTSkipUnless(
+            ProcessInfo.processInfo.environment["KETCH_INTEGRATION_TESTS"] == "1",
+            "Set KETCH_INTEGRATION_TESTS=1 to run live CDN tests"
+        )
+        cancellables = []
+    }
+
+    override func tearDown() {
+        cancellables.removeAll()
+        super.tearDown()
+    }
+
+    private func makeKetch() -> Ketch {
+        Ketch(
+            organizationCode: HeadlessIntegrationSupport.orgCode,
+            propertyCode: HeadlessIntegrationSupport.propertyCode,
+            environmentCode: HeadlessIntegrationSupport.environmentCode,
+            identities: []
+        )
+    }
+
+    func testGetRegion_liveCDN_returnsRealValue() {
+        let ketch = makeKetch()
+        let expectation = expectation(description: "getRegion")
+        ketch.getRegion { result in
+            switch result {
+            case .success(let region):
+                XCTAssertFalse(region?.isEmpty ?? true, "Expected a non-empty region code from live GeoIP")
+            case .failure(let error):
+                XCTFail("getRegion failed: \(error)")
+            }
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 45)
+    }
+
+    func testGetRegion_liveCDN_secondCallServedFromCache() {
+        let ketch = makeKetch()
+        let first = expectation(description: "first getRegion")
+        var firstRegion: String?
+        ketch.getRegion { result in
+            firstRegion = try? result.get()
+            first.fulfill()
+        }
+        wait(for: [first], timeout: 45)
+
+        // A second call immediately after should return the same cached value without erroring.
+        let second = expectation(description: "second getRegion")
+        ketch.getRegion { result in
+            XCTAssertEqual(try? result.get(), firstRegion)
+            second.fulfill()
+        }
+        wait(for: [second], timeout: 5)
+    }
+
+    func testGetJurisdiction_liveCDN_returnsRealValue() {
+        let ketch = makeKetch()
+        let expectation = expectation(description: "getJurisdiction")
+        ketch.getJurisdiction { result in
+            switch result {
+            case .success(let jurisdiction):
+                XCTAssertFalse(jurisdiction?.isEmpty ?? true, "Expected a non-empty jurisdiction code from live config")
+            case .failure(let error):
+                XCTFail("getJurisdiction failed: \(error)")
+            }
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 45)
+    }
+
+    func testStaticGetRegion_liveCDN_returnsRealValue() {
+        let expectation = expectation(description: "static getRegion")
+        KetchSDK.getRegion()
+            .sink { completion in
+                if case .failure(let error) = completion { XCTFail("static getRegion failed: \(error)") }
+            } receiveValue: { region in
+                XCTAssertFalse(region?.isEmpty ?? true, "Expected a non-empty region code from live GeoIP")
+            }
+            .store(in: &cancellables)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5) { expectation.fulfill() }
+        wait(for: [expectation], timeout: 45)
+    }
+
+    func testStaticGetJurisdiction_liveCDN_returnsRealValue() {
+        let expectation = expectation(description: "static getJurisdiction")
+        let request = KetchSDK.FullConfigurationRequest(
+            organizationCode: HeadlessIntegrationSupport.orgCode,
+            propertyCode: HeadlessIntegrationSupport.propertyCode,
+            environmentCode: HeadlessIntegrationSupport.environmentCode
+        )
+        KetchSDK.getJurisdiction(request: request)
+            .sink { completion in
+                if case .failure(let error) = completion { XCTFail("static getJurisdiction failed: \(error)") }
+            } receiveValue: { jurisdiction in
+                XCTAssertFalse(jurisdiction?.isEmpty ?? true, "Expected a non-empty jurisdiction code from live config")
+            }
+            .store(in: &cancellables)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5) { expectation.fulfill() }
+        wait(for: [expectation], timeout: 45)
+    }
+
+    /// Drives a real WKWebView against the live CDN. Confirms the cold path (called before config
+    /// loads, deferred) and the warm path (called after config loads, fires immediately) both
+    /// return `true` and neither crashes nor throws at the Swift/JS bridge. This does not assert an
+    /// experience actually appeared — that requires a backend onFunction rule for the given
+    /// function name configured on the sandbox org, which is outside this test's control.
+    func testTrigger_liveCDN_coldThenWarmPath() {
+        let ketch = makeKetch()
+        let ketchUI = KetchUI(ketch: ketch)
+
+        // Cold path: fired immediately after init, before the tag has had a chance to boot.
+        let coldAccepted = ketchUI.trigger(triggerName: .custom, functionName: "smokeTestColdTrigger")
+        XCTAssertTrue(coldAccepted, "Cold trigger() should be accepted (deferred) even before config loads")
+
+        let configLoaded = expectation(description: "configuration loaded")
+        ketchUI.$configuration
+            .compactMap { $0 }
+            .first()
+            .sink { _ in configLoaded.fulfill() }
+            .store(in: &cancellables)
+        wait(for: [configLoaded], timeout: 45)
+
+        // Warm path: config is now loaded, so this should fire immediately via evaluateJavaScript.
+        let warmAccepted = ketchUI.trigger(triggerName: .custom, functionName: "smokeTestWarmTrigger")
+        XCTAssertTrue(warmAccepted, "Warm trigger() should be accepted once config has loaded")
+    }
+
+    func testTrigger_liveCDN_rejectsInvalidFunctionName() {
+        let ketch = makeKetch()
+        let ketchUI = KetchUI(ketch: ketch)
+        XCTAssertFalse(ketchUI.trigger(triggerName: .custom, functionName: ""))
+        XCTAssertFalse(ketchUI.trigger(triggerName: .custom, functionName: "has space"))
+    }
+}

--- a/Tests/KetchSDKTests/LocationRegionCodeTests.swift
+++ b/Tests/KetchSDKTests/LocationRegionCodeTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+@testable import KetchSDK
+
+final class LocationRegionCodeTests: XCTestCase {
+    private func ipInfo(countryCode: String?, regionCode: String?) -> KetchSDK.IPInfo {
+        KetchSDK.IPInfo(
+            ip: nil,
+            hostname: nil,
+            continentCode: nil,
+            continentName: nil,
+            countryCode: countryCode,
+            countryName: nil,
+            regionCode: regionCode,
+            regionName: nil,
+            city: nil,
+            postalCode: nil,
+            timezone: nil
+        )
+    }
+
+    func testToRegionCode_countryAndRegion_combinesWithHyphen() {
+        XCTAssertEqual(ipInfo(countryCode: "US", regionCode: "CA").toRegionCode(), "US-CA")
+    }
+
+    func testToRegionCode_countryOnly() {
+        XCTAssertEqual(ipInfo(countryCode: "US", regionCode: nil).toRegionCode(), "US")
+    }
+
+    func testToRegionCode_countryOnly_blankRegion() {
+        XCTAssertEqual(ipInfo(countryCode: "US", regionCode: "").toRegionCode(), "US")
+    }
+
+    func testToRegionCode_regionOnly_whenCountryAbsent() {
+        XCTAssertEqual(ipInfo(countryCode: nil, regionCode: "CA").toRegionCode(), "CA")
+    }
+
+    func testToRegionCode_regionOnly_whenCountryBlank() {
+        XCTAssertEqual(ipInfo(countryCode: "", regionCode: "CA").toRegionCode(), "CA")
+    }
+
+    func testToRegionCode_bothAbsent_returnsNil() {
+        XCTAssertNil(ipInfo(countryCode: nil, regionCode: nil).toRegionCode())
+    }
+
+    func testToRegionCode_bothBlank_returnsNil() {
+        XCTAssertNil(ipInfo(countryCode: "", regionCode: "").toRegionCode())
+    }
+}


### PR DESCRIPTION
## Description of this change

Middle layer of a 3-PR stack for the headless SDK surface. Review this PR's diff against its base (#80).

```
main
 └── #80   native storage dispatch
  └── #92   headless core + tests   ← this PR
   └── #93   policy/trigger parity + privacy strings
```

- Headless web/v3 API client (`HeadlessApiClient`, config entities, data-center routing)
- Consent API exposed as static methods
- Instance headless surface with config caching and local region/jurisdiction preference
- BCP-47 language-tag normalization; environment retained on config requests
- Unit and integration tests for the client and consent paths

## Why is this change being made?

- [ ] Chore (non-functional changes)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

The consent API is exposed as static methods, changing the call site for consumers of the previous instance methods.

## How was this tested? How can the reviewer verify your testing?

- XCTest coverage in `Tests/KetchSDKTests` (headless client, consent stubs, BCP-47 normalization, caching).
- Reviewer: check CI on this PR; `swift test` locally if desired.

## Related issues

None.

## Checklist

- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have evaluated the security impact of this change, and [OWASP Secure Coding Practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/migrated_content#) have been observed.
- [ ] I have informed stakeholders of my changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large networking migration to web/v3 plus breaking public API changes (static consent/config) and altered consent read/write semantics that affect all integrators.
> 
> **Overview**
> Adds a **native headless layer** aligned with ketch-tag **web/v3**: `HeadlessApiClient` and `KetchDataCenter` (US/EU/UAT) replace the old v2 `EndPoint` builders; `KetchApiRequest` delegates CDN calls through the headless client while locale strings still use the static CDN.
> 
> **Public API:** `KetchSDK` gains static headless publishers (GeoIP, bootstrap/full config, consent, rights, subscriptions, preference QR). Legacy config/consent helpers move to **`KetchSDK` static** methods (breaking for code that called them on an instance). `Ketch.create` accepts optional `dataCenter`. `Ketch` exposes completion-based headless APIs with **in-memory caching** for `GET /ip` and full config (keyed via `FullConfigurationRequest` path/query helpers), plus **`setRegion` / `setJurisdiction`** overrides that invalidate config cache.
> 
> **Consent behavior:** Updates go through v3 `setConsent`, return **`ConsentStatus`** (including server `protocols`), omit `protocols` from the POST body, and merge/fallback on sparse responses. Instance `updateConsent` / `loadConsent(consentConfig:)` publish server status instead of synthesizing locally.
> 
> **Config URLs:** `FullConfigurationRequest` centralizes long vs short config paths, blank-field handling, BCP-47 language tags, and hash query params. **`KetchUI`** auto-appends the data-center base URL to WebView experience options when not already set.
> 
> New unit and opt-in CDN integration tests cover URL building, consent contracts, caching, and language normalization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51b61b5220c28b7c476921f674818d89f96e1dce. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->